### PR TITLE
Tyjen/develop

### DIFF
--- a/Common/Deployment/RemoteMonitoring.json
+++ b/Common/Deployment/RemoteMonitoring.json
@@ -1,650 +1,749 @@
 {
-    "$schema" : "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
-    "contentVersion" : "1.0.0.0",
-    "parameters" : {
-        "AADTenant" : {
-            "type" : "string",
-            "metadata" : {
-                "description" : "The name of the service Tenant"
+    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "AADTenant": {
+            "type": "string",
+            "metadata": {
+                "description": "The name of the service Tenant"
             }
         },
-        "packageUri" : {
-            "type" : "string",
-            "defaultValue" : "http://aka.ms/azureiot/remotemonitoring"
+        "packageUri": {
+            "type": "string",
+            "defaultValue": "http://aka.ms/azureiot/remotemonitoring"
         },
-        "webJobPackageUri" : {
-            "type" : "string",
-            "defaultValue" : "http://aka.ms/azureiot/remotemonitoring/webjob"
+        "webJobPackageUri": {
+            "type": "string",
+            "defaultValue": "http://aka.ms/azureiot/remotemonitoring/webjob"
         }
     },
-    "variables" : {
-        "name" : "[resourceGroup().name]",
-        "storageAccountType" : "Standard_LRS",
-        "location" : "[resourceGroup().location]",
-        "storageVersion" : "2015-05-01-preview",
-        "storageName" : "[toLower(concat(variables('name'), 'store'))]",
-        "storageId" : "[resourceId('Microsoft.Storage/storageAccounts', variables('storageName'))]",
-        "sbVersion" : "[providers('Microsoft.Eventhub', 'namespaces').apiVersions[0]]",
-        "sbName" : "[concat(variables('name'), '-servicebus')]",
-        "ehOutName" : "[concat(variables('name'), '-ehout')]",
-        "ehRuleOutName" : "[concat(variables('name'), '-ehruleout')]",
-        "sbKeyName" : "RootManageSharedAccessKey",
-        "sbResourceId" : "[resourceId('Microsoft.Eventhub/namespaces/authorizationRules', variables('sbName'), variables('sbKeyName'))]",
-        "saVersion" : "2015-06-01",
-        "webVersion" : "2015-04-01",
-        "bingMapsName" : "[concat(variables('name'), '-map')]",
-        "bingMapsVersion" : "2015-07-02",
-        "webJobPlanName": "[concat(variables('name'), '-jobs-plan')]",
-        "webJobSku" : "Basic",
-        "webJobWorkerSize" : "0",
+    "variables": {
+        "name": "[resourceGroup().name]",
+        "storageAccountType": "Standard_GRS",
+        "location": "[resourceGroup().location]",
+        "storageVersion": "2015-05-01-preview",
+        "storageName": "[toLower(concat(variables('name'), 'store'))]",
+        "storageId": "[resourceId('Microsoft.Storage/storageAccounts', variables('storageName'))]",
+        "sbVersion": "[providers('Microsoft.Eventhub', 'namespaces').apiVersions[0]]",
+        "sbName": "[concat(variables('name'), '-servicebus')]",
+        "ehOutName": "[concat(variables('name'), '-ehout')]",
+        "ehRuleOutName": "[concat(variables('name'), '-ehruleout')]",
+        "sbKeyName": "RootManageSharedAccessKey",
+        "sbResourceId": "[resourceId('Microsoft.Eventhub/namespaces/authorizationRules', variables('sbName'), variables('sbKeyName'))]",
+        "saVersion": "2015-06-01",
+        "webVersion": "2015-04-01",
+        "bingMapsName": "[concat(variables('name'), '-map')]",
+        "bingMapsVersion": "2015-07-02",
+        "webJobPlanName": "[concat(variables('name'), '-jobsplan')]",
+        "webJobSku": "Standard",
+        "webJobWorkerSize": "0",
         "webJobWorkerCount": "2",
         "webJobSiteName": "[concat(variables('name'), '-jobhost')]",
         "webPlanName": "[concat(variables('name'), '-plan')]",
         "webSiteName": "[variables('name')]",
-        "webSku" : "Basic",
-        "webWorkerSize" : "0",
-        "webWorkerCount" : "2",
-        "AADMetadataAddress" : "[concat('https://login.windows.net/' , parameters('AADTenant'), '/FederationMetadata/2007-06/FederationMetadata.xml')]",
-        "AADRealm" : "[toLower(concat('https://', variables('webSiteName'), '.azurewebsites.net/iotsuite'))]",
-        "docDBVersion" : "2015-04-08",
-        "docDBName" : "[toLower(concat(variables('name'), '-IotSuite'))]",
-        "docDBSku" : "Standard",
-        "iotHubVersion" : "2015-08-15-preview",
-        "iotHubSku" : "S1",
-        "iotHubTier" : "Standard",
-        "iotHubResourceId" : "[resourceId('Microsoft.Devices/Iothubs', variables('name'))]",
-        "iotHubKeyName" : "iothubowner",
-        "iotHubKeyResource" : "[resourceId('Microsoft.Devices/Iothubs/Iothubkeys', variables('name'), variables('iotHubKeyName'))]"
+        "webSku": "Standard",
+        "webWorkerSize": "0",
+        "webWorkerCount": "2",
+        "AADMetadataAddress": "[concat('https://login.windows.net/' , parameters('AADTenant'), '/FederationMetadata/2007-06/FederationMetadata.xml')]",
+        "AADRealm": "[toLower(concat('https://', variables('webSiteName'), '.azurewebsites.net/iotsuite'))]",
+        "docDBVersion": "2015-04-08",
+        "docDBName": "[toLower(concat(variables('name'), '-IotSuite'))]",
+        "docDBSku": "Standard",
+        "iotHubVersion": "2015-08-15-preview",
+        "iotHubSku": "S2",
+        "iotHubTier": "Standard",
+        "iotHubResourceId": "[resourceId('Microsoft.Devices/Iothubs', variables('name'))]",
+        "iotHubKeyName": "iothubowner",
+        "iotHubKeyResource": "[resourceId('Microsoft.Devices/Iothubs/Iothubkeys', variables('name'), variables('iotHubKeyName'))]",
+        "rulesCGName": "rulescg",
+        "deviceInfoCGName": "deviceinfocg",
+        "telemetryCGName": "telemetrycg"
     },
-    "resources" : [{
-            "apiVersion" : "[variables('docDBVersion')]",
-            "type" : "Microsoft.DocumentDb/databaseAccounts",
-            "name" : "[variables('docDBName')]",
-            "location" : "[variables('location')]",
-            "properties" : {
-                "name" : "[variables('docDBName')]",
-                "databaseAccountOfferType" : "[variables('docDBSku')]"
+    "resources": [
+        {
+            "apiVersion": "[variables('docDBVersion')]",
+            "type": "Microsoft.DocumentDb/databaseAccounts",
+            "name": "[variables('docDBName')]",
+            "location": "[variables('location')]",
+            "properties": {
+                "name": "[variables('docDBName')]",
+                "databaseAccountOfferType": "[variables('docDBSku')]"
             }
-        }, {
-            "apiVersion" : "[variables('bingMapsVersion')]",
-            "type" : "Microsoft.BingMaps/mapApis",
-            "name" : "[variables('bingMapsName')]",
-            "location" : "westus",
-            "plan" : {
-                "publisher" : "bingmaps",
-                "product" : "mapapis",
-                "name" : "internal1",
-                "promotionCode" : null
+        },
+        {
+            "apiVersion": "[variables('bingMapsVersion')]",
+            "type": "Microsoft.BingMaps/mapApis",
+            "name": "[variables('bingMapsName')]",
+            "location": "westus",
+            "plan": {
+                "publisher": "bingmaps",
+                "product": "mapapis",
+                "name": "internal1",
+                "promotionCode": null
             },
-            "properties" : {}
-        }, {
-            "apiVersion" : "[variables('storageVersion')]",
-            "type" : "Microsoft.Storage/storageAccounts",
-            "name" : "[variables('storageName')]",
-            "location" : "[variables('location')]",
-            "properties" : {
-                "accountType" : "[variables('storageAccountType')]"
+            "properties": { }
+        },
+        {
+            "apiVersion": "[variables('storageVersion')]",
+            "type": "Microsoft.Storage/storageAccounts",
+            "name": "[variables('storageName')]",
+            "location": "[variables('location')]",
+            "properties": {
+                "accountType": "[variables('storageAccountType')]"
             }
-        }, {
-            "apiVersion" : "[variables('iotHubVersion')]",
-            "type" : "Microsoft.Devices/Iothubs",
-            "name" : "[variables('name')]",
-            "location" : "[variables('location')]",
-            "sku" : {
-                "name" : "[variables('iotHubSku')]",
-                "tier" : "[variables('iotHubTier')]",
-                "capacity" : 1
+        },
+        {
+            "apiVersion": "[variables('iotHubVersion')]",
+            "type": "Microsoft.Devices/Iothubs",
+            "name": "[variables('name')]",
+            "location": "[variables('location')]",
+            "sku": {
+                "name": "[variables('iotHubSku')]",
+                "tier": "[variables('iotHubTier')]",
+                "capacity": 1
             },
-            "properties" : {
-                "location" : "[variables('location')]"
+            "properties": {
+                "location": "[variables('location')]"
             }
-        }, {
-            "apiVersion" : "[variables('sbVersion')]",
-            "name" : "[variables('sbName')]",
-            "type" : "Microsoft.Eventhub/namespaces",
-            "location" : "[variables('location')]",
-            "properties" : {
-                "region" : "[variables('location')]"
+        },
+        {
+            "apiVersion": "[variables('iotHubVersion')]",
+            "name": "[concat(variables('name'), '/events/', variables('rulesCGName'))]",
+            "type": "Microsoft.Devices/Iothubs/eventhubEndpoints/ConsumerGroups",
+            "dependsOn": [
+                "[concat('Microsoft.Devices/Iothubs/', variables('name'))]"
+            ]
+        },
+        {
+            "apiVersion": "[variables('iotHubVersion')]",
+            "name": "[concat(variables('name'), '/events/', variables('deviceInfoCGName'))]",
+            "type": "Microsoft.Devices/Iothubs/eventhubEndpoints/ConsumerGroups",
+            "dependsOn": [
+                "[concat('Microsoft.Devices/Iothubs/', variables('name'))]"
+            ]
+        },
+        {
+            "apiVersion": "[variables('iotHubVersion')]",
+            "name": "[concat(variables('name'), '/events/', variables('telemetryCGName'))]",
+            "type": "Microsoft.Devices/Iothubs/eventhubEndpoints/ConsumerGroups",
+            "dependsOn": [
+                "[concat('Microsoft.Devices/Iothubs/', variables('name'))]"
+            ]
+        },
+        {
+            "apiVersion": "[variables('sbVersion')]",
+            "name": "[variables('sbName')]",
+            "type": "Microsoft.Eventhub/namespaces",
+            "location": "[variables('location')]",
+            "properties": {
+                "messagingSku": 1,
+                "region": "[variables('location')]"
             },
-            "resources" : [{
-                    "apiVersion" : "[variables('sbVersion')]",
-                    "name" : "[variables('ehOutName')]",
-                    "type" : "eventHubs",
-                    "location" : "[variables('location')]",
-                    "dependsOn" : [
+            "resources": [
+                {
+                    "apiVersion": "[variables('sbVersion')]",
+                    "name": "[variables('ehOutName')]",
+                    "type": "eventHubs",
+                    "location": "[variables('location')]",
+                    "dependsOn": [
                         "[concat('Microsoft.Eventhub/namespaces/', variables('sbName'))]"
                     ],
-                    "properties" : {
-                        "path" : "[variables('ehOutName')]"
+                    "properties": {
+                        "path": "[variables('ehOutName')]"
                     }
-                }, {
-                    "apiVersion" : "[variables('sbVersion')]",
-                    "name" : "[variables('ehRuleOutName')]",
-                    "type" : "eventHubs",
-                    "location" : "[variables('location')]",
-                    "dependsOn" : [
+                },
+                {
+                    "apiVersion": "[variables('sbVersion')]",
+                    "name": "[variables('ehRuleOutName')]",
+                    "type": "eventHubs",
+                    "location": "[variables('location')]",
+                    "dependsOn": [
                         "[concat('Microsoft.Eventhub/namespaces/', variables('sbName'))]"
                     ],
-                    "properties" : {
-                        "path" : "[variables('ehRuleOutName')]"
+                    "properties": {
+                        "path": "[variables('ehRuleOutName')]"
                     }
                 }
             ]
-        }, {
-            "apiVersion" : "[variables('saVersion')]",
-            "type" : "Microsoft.StreamAnalytics/streamingjobs",
-            "name" : "[concat(variables('name'), '-Telemetry')]",
-            "location" : "[variables('location')]",
-            "dependsOn" : [
+        },
+        {
+            "apiVersion": "[variables('saVersion')]",
+            "type": "Microsoft.StreamAnalytics/streamingjobs",
+            "name": "[concat(variables('name'), '-Telemetry')]",
+            "location": "[variables('location')]",
+            "dependsOn": [
                 "[concat('Microsoft.Storage/storageAccounts/', variables('storageName'))]",
                 "[concat('Microsoft.Devices/Iothubs/', variables('name'))]"
             ],
-            "properties" : {
-                "sku" : {
-                    "name" : "standard"
+            "properties": {
+                "sku": {
+                    "name": "standard"
                 },
-                "EventsOutOfOrderMaxDelayInSeconds" : 10,
-                "EventsOutOfOrderPolicy" : "adjust",
-                "Inputs" : [{
-                        "Name" : "IoTHubStream",
-                        "Properties" : {
-                            "DataSource" : {
-                                "Properties" : {
-                                    "ConsumerGroupName" : "",
-                                    "EventHubName" : "[reference(variables('iotHubResourceId')).eventHubEndpoints.events.path]",
-                                    "ServiceBusNamespace" : "[split(split(reference(variables('iotHubResourceId')).eventHubEndpoints.events.endpoint, '/')[2], '.')[0]]",
-                                    "SharedAccessPolicyKey" : "[listkeys(variables('iotHubKeyResource'), variables('iotHubVersion')).primaryKey]",
-                                    "SharedAccessPolicyName" : "[variables('iotHubKeyName')]"
+                "EventsOutOfOrderMaxDelayInSeconds": 10,
+                "EventsOutOfOrderPolicy": "adjust",
+                "Inputs": [
+                    {
+                        "Name": "IoTHubStream",
+                        "Properties": {
+                            "DataSource": {
+                                "Properties": {
+                                    "ConsumerGroupName": "[variables('telemetryCGName')]",
+                                    "EventHubName": "[reference(variables('iotHubResourceId')).eventHubEndpoints.events.path]",
+                                    "ServiceBusNamespace": "[split(split(reference(variables('iotHubResourceId')).eventHubEndpoints.events.endpoint, '/')[2], '.')[0]]",
+                                    "SharedAccessPolicyKey": "[listkeys(variables('iotHubKeyResource'), variables('iotHubVersion')).primaryKey]",
+                                    "SharedAccessPolicyName": "[variables('iotHubKeyName')]"
                                 },
-                                "Type" : "Microsoft.ServiceBus/EventHub"
+                                "Type": "Microsoft.ServiceBus/EventHub"
                             },
-                            "Serialization" : {
-                                "Properties" : {
-                                    "Encoding" : "UTF8"
+                            "Serialization": {
+                                "Properties": {
+                                    "Encoding": "UTF8"
                                 },
-                                "Type" : "Json"
+                                "Type": "Json"
                             },
-                            "Type" : "Stream"
+                            "Type": "Stream"
                         }
                     }
                 ],
-                "Outputs" : [{
-                        "Name" : "Telemetry",
-                        "Properties" : {
-                            "DataSource" : {
-                                "Properties" : {
-                                    "Container" : "DeviceTelemetry",
-                                    "DateFormat" : "yyyy/MM/dd",
-                                    "TimeFormat" : "HH",
-                                    "PathPattern" : "devicetelemetry/{date}/{time}",
-                                    "StorageAccounts" : [{
-                                            "AccountKey" : "[listkeys(variables('storageId'), variables('storageVersion')).key1]",
-                                            "AccountName" : "[variables('storageName')]"
+                "Outputs": [
+                    {
+                        "Name": "Telemetry",
+                        "Properties": {
+                            "DataSource": {
+                                "Properties": {
+                                    "Container": "DeviceTelemetry",
+                                    "DateFormat": "yyyy/MM/dd",
+                                    "TimeFormat": "HH",
+                                    "PathPattern": "devicetelemetry/{date}/{time}",
+                                    "StorageAccounts": [
+                                        {
+                                            "AccountKey": "[listkeys(variables('storageId'), variables('storageVersion')).key1]",
+                                            "AccountName": "[variables('storageName')]"
                                         }
                                     ]
                                 },
-                                "Type" : "Microsoft.Storage/Blob"
+                                "Type": "Microsoft.Storage/Blob"
                             },
-                            "Serialization" : {
-                                "Properties" : {
-                                    "Encoding" : "UTF8",
-                                    "FieldDelimiter" : ","
+                            "Serialization": {
+                                "Properties": {
+                                    "Encoding": "UTF8",
+                                    "FieldDelimiter": ","
                                 },
-                                "Type" : "Csv"
+                                "Type": "Csv"
                             }
                         }
-                    }, {
-                        "Name" : "TelemetrySummary",
-                        "Properties" : {
-                            "DataSource" : {
-                                "Properties" : {
-                                    "Container" : "devicetelemetry",
-                                    "DateFormat" : "yyyy/MM/dd",
-                                    "TimeFormat" : "HH",
-                                    "PathPattern" : "devicetelemetry-summary/{date}/{time}",
-                                    "StorageAccounts" : [{
-                                            "AccountKey" : "[listkeys(variables('storageId'), variables('storageVersion')).key1]",
-                                            "AccountName" : "[variables('storageName')]"
+                    },
+                    {
+                        "Name": "TelemetrySummary",
+                        "Properties": {
+                            "DataSource": {
+                                "Properties": {
+                                    "Container": "devicetelemetry",
+                                    "DateFormat": "yyyy/MM/dd",
+                                    "TimeFormat": "HH",
+                                    "PathPattern": "devicetelemetry-summary/{date}/{time}",
+                                    "StorageAccounts": [
+                                        {
+                                            "AccountKey": "[listkeys(variables('storageId'), variables('storageVersion')).key1]",
+                                            "AccountName": "[variables('storageName')]"
                                         }
                                     ]
                                 },
-                                "Type" : "Microsoft.Storage/Blob"
+                                "Type": "Microsoft.Storage/Blob"
                             },
-                            "Serialization" : {
-                                "Properties" : {
-                                    "Encoding" : "UTF8",
-                                    "FieldDelimiter" : ","
+                            "Serialization": {
+                                "Properties": {
+                                    "Encoding": "UTF8",
+                                    "FieldDelimiter": ","
                                 },
-                                "Type" : "Csv"
+                                "Type": "Csv"
                             }
                         }
                     }
                 ],
-                "Transformation" : {
-                    "Name" : "AllToBlob",
-                    "Properties" : {
-                        "Query" : "WITH \r\n    [StreamData]\r\nAS (\r\n    SELECT\r\n        *\r\n    FROM \r\n      [IoTHubStream] \r\n    WHERE\r\n        [ObjectType] IS NULL -- Filter out device info and command responses\r\n) \r\n\r\nSELECT\r\n    *\r\nINTO\r\n    [Telemetry]\r\nFROM\r\n    [StreamData]\r\n\r\nSELECT\r\n    DeviceId,\r\n    AVG (Humidity) AS [AverageHumidity], \r\n    MIN(Humidity) AS [MinimumHumidity], \r\n    MAX(Humidity) AS [MaxHumidity], \r\n    5.0 AS TimeframeMinutes \r\nINTO\r\n    [TelemetrySummary]\r\nFROM\r\n    [StreamData]\r\nWHERE\r\n    [Humidity] IS NOT NULL\r\nGROUP BY\r\n    DeviceId, \r\n    SlidingWindow (mi, 5)",
-                        "StreamingUnits" : 1
+                "Transformation": {
+                    "Name": "AllToBlob",
+                    "Properties": {
+                        "Query": "WITH \r\n    [StreamData]\r\nAS (\r\n    SELECT\r\n        *\r\n    FROM \r\n      [IoTHubStream] \r\n    WHERE\r\n        [ObjectType] IS NULL -- Filter out device info and command responses\r\n) \r\n\r\nSELECT\r\n    *\r\nINTO\r\n    [Telemetry]\r\nFROM\r\n    [StreamData]\r\n\r\nSELECT\r\n    DeviceId,\r\n    AVG (Humidity) AS [AverageHumidity], \r\n    MIN(Humidity) AS [MinimumHumidity], \r\n    MAX(Humidity) AS [MaxHumidity], \r\n    5.0 AS TimeframeMinutes \r\nINTO\r\n    [TelemetrySummary]\r\nFROM\r\n    [StreamData]\r\nWHERE\r\n    [Humidity] IS NOT NULL\r\nGROUP BY\r\n    DeviceId, \r\n    SlidingWindow (mi, 5)",
+                        "StreamingUnits": 1
                     }
                 }
             }
-        }, {
-            "apiVersion" : "[variables('saVersion')]",
-            "type" : "Microsoft.StreamAnalytics/streamingjobs",
-            "name" : "[concat(variables('name'), '-DeviceInfo')]",
-            "location" : "[variables('location')]",
-            "dependsOn" : [
+        },
+        {
+            "apiVersion": "[variables('saVersion')]",
+            "type": "Microsoft.StreamAnalytics/streamingjobs",
+            "name": "[concat(variables('name'), '-DeviceInfo')]",
+            "location": "[variables('location')]",
+            "dependsOn": [
                 "[concat('Microsoft.Eventhub/namespaces/', variables('sbName'))]",
                 "[concat('Microsoft.Devices/Iothubs/', variables('name'))]"
             ],
-            "properties" : {
-                "sku" : {
-                    "name" : "standard"
+            "properties": {
+                "sku": {
+                    "name": "standard"
                 },
-                "EventsOutOfOrderMaxDelayInSeconds" : 10,
-                "EventsOutOfOrderPolicy" : "adjust",
-                "Inputs" : [{
-                        "Name" : "DeviceDataStream",
-                        "Properties" : {
-                            "DataSource" : {
-                                "Properties" : {
-                                    "ConsumerGroupName" : "",
-                                    "EventHubName" : "[reference(variables('iotHubResourceId')).eventHubEndpoints.events.path]",
-                                    "ServiceBusNamespace" : "[split(split(reference(variables('iotHubResourceId')).eventHubEndpoints.events.endpoint, '/')[2], '.')[0]]",
-                                    "SharedAccessPolicyKey" : "[listkeys(variables('iotHubKeyResource'), variables('iotHubVersion')).primaryKey]",
-                                    "SharedAccessPolicyName" : "[variables('iotHubKeyName')]"
+                "EventsOutOfOrderMaxDelayInSeconds": 10,
+                "EventsOutOfOrderPolicy": "adjust",
+                "Inputs": [
+                    {
+                        "Name": "DeviceDataStream",
+                        "Properties": {
+                            "DataSource": {
+                                "Properties": {
+                                    "ConsumerGroupName": "[variables('deviceInfoCGName')]",
+                                    "EventHubName": "[reference(variables('iotHubResourceId')).eventHubEndpoints.events.path]",
+                                    "ServiceBusNamespace": "[split(split(reference(variables('iotHubResourceId')).eventHubEndpoints.events.endpoint, '/')[2], '.')[0]]",
+                                    "SharedAccessPolicyKey": "[listkeys(variables('iotHubKeyResource'), variables('iotHubVersion')).primaryKey]",
+                                    "SharedAccessPolicyName": "[variables('iotHubKeyName')]"
                                 },
-                                "Type" : "Microsoft.ServiceBus/EventHub"
+                                "Type": "Microsoft.ServiceBus/EventHub"
                             },
-                            "Serialization" : {
-                                "Properties" : {
-                                    "Encoding" : "UTF8"
+                            "Serialization": {
+                                "Properties": {
+                                    "Encoding": "UTF8"
                                 },
-                                "Type" : "Json"
+                                "Type": "Json"
                             },
-                            "Type" : "Stream"
+                            "Type": "Stream"
                         }
                     }
                 ],
-                "Outputs" : [{
-                        "Name" : "DeviceInfoEvents",
-                        "Properties" : {
-                            "DataSource" : {
-                                "Properties" : {
-                                    "EventHubName" : "[variables('ehOutName')]",
-                                    "ServiceBusNamespace" : "[variables('sbName')]",
-                                    "SharedAccessPolicyKey" : "[listkeys(variables('sbResourceId'), variables('sbVersion')).primaryKey]",
-                                    "SharedAccessPolicyName" : "[variables('sbKeyName')]",
-                                    "PartitionKey" : "PartitionId"
+                "Outputs": [
+                    {
+                        "Name": "DeviceInfoEvents",
+                        "Properties": {
+                            "DataSource": {
+                                "Properties": {
+                                    "EventHubName": "[variables('ehOutName')]",
+                                    "ServiceBusNamespace": "[variables('sbName')]",
+                                    "SharedAccessPolicyKey": "[listkeys(variables('sbResourceId'), variables('sbVersion')).primaryKey]",
+                                    "SharedAccessPolicyName": "[variables('sbKeyName')]",
+                                    "PartitionKey": "PartitionId"
                                 },
-                                "Type" : "Microsoft.ServiceBus/EventHub"
+                                "Type": "Microsoft.ServiceBus/EventHub"
                             },
-                            "Serialization" : {
-                                "Properties" : {
-                                    "Encoding" : "UTF8",
-                                    "Format" : "Array"
+                            "Serialization": {
+                                "Properties": {
+                                    "Encoding": "UTF8",
+                                    "Format": "Array"
                                 },
-                                "Type" : "Json"
+                                "Type": "Json"
                             }
                         }
                     }
                 ],
-                "Transformation" : {
-                    "Name" : "DeviceInfoFilter",
-                    "Properties" : {
-                        "Query" : "SELECT * FROM DeviceDataStream Partition By PartitionId WHERE  ObjectType = 'DeviceInfo'",
-                        "StreamingUnits" : 1
+                "Transformation": {
+                    "Name": "DeviceInfoFilter",
+                    "Properties": {
+                        "Query": "SELECT * FROM DeviceDataStream Partition By PartitionId WHERE  ObjectType = 'DeviceInfo'",
+                        "StreamingUnits": 1
                     }
                 }
             }
-        }, {
-            "apiVersion" : "[variables('saVersion')]",
-            "type" : "Microsoft.StreamAnalytics/streamingjobs",
-            "name" : "[concat(variables('name'), '-Rules')]",
-            "location" : "[variables('location')]",
-            "dependsOn" : [
+        },
+        {
+            "apiVersion": "[variables('saVersion')]",
+            "type": "Microsoft.StreamAnalytics/streamingjobs",
+            "name": "[concat(variables('name'), '-Rules')]",
+            "location": "[variables('location')]",
+            "dependsOn": [
                 "[concat('Microsoft.Storage/storageAccounts/', variables('storageName'))]",
                 "[concat('Microsoft.Eventhub/namespaces/', variables('sbName'))]",
                 "[concat('Microsoft.Devices/Iothubs/', variables('name'))]"
             ],
-            "properties" : {
-                "sku" : {
-                    "name" : "standard"
+            "properties": {
+                "sku": {
+                    "name": "standard"
                 },
-                "EventsOutOfOrderMaxDelayInSeconds" : 10,
-                "EventsOutOfOrderPolicy" : "adjust",
-                "Inputs" : [{
-                        "Name" : "DeviceRulesBlob",
-                        "Properties" : {
-                            "DataSource" : {
-                                "Properties" : {
-                                    "Container" : "devicerules",
-                                    "DateFormat" : "yyyy-MM-dd",
-                                    "PathPattern" : "{date}/{time}/devicerules.json",
-                                    "BlobName" : "{date}/{time}/devicerules.json",
-                                    "StorageAccounts" : [{
-                                            "AccountKey" : "[listkeys(variables('storageId'), variables('storageVersion')).key1]",
-                                            "AccountName" : "[variables('storageName')]"
+                "EventsOutOfOrderMaxDelayInSeconds": 10,
+                "EventsOutOfOrderPolicy": "adjust",
+                "Inputs": [
+                    {
+                        "Name": "DeviceRulesBlob",
+                        "Properties": {
+                            "DataSource": {
+                                "Properties": {
+                                    "Container": "devicerules",
+                                    "DateFormat": "yyyy-MM-dd",
+                                    "PathPattern": "{date}/{time}/devicerules.json",
+                                    "BlobName": "{date}/{time}/devicerules.json",
+                                    "StorageAccounts": [
+                                        {
+                                            "AccountKey": "[listkeys(variables('storageId'), variables('storageVersion')).key1]",
+                                            "AccountName": "[variables('storageName')]"
                                         }
                                     ],
-                                    "TimeFormat" : "HH-mm"
+                                    "TimeFormat": "HH-mm"
                                 },
-                                "Type" : "Microsoft.Storage/Blob"
+                                "Type": "Microsoft.Storage/Blob"
                             },
-                            "Serialization" : {
-                                "Properties" : {
-                                    "Encoding" : "UTF8"
+                            "Serialization": {
+                                "Properties": {
+                                    "Encoding": "UTF8"
                                 },
-                                "Type" : "Json"
+                                "Type": "Json"
                             },
-                            "Type" : "Reference"
+                            "Type": "Reference"
                         }
-                    }, {
-                        "Name" : "IotTelemetryStream",
-                        "Properties" : {
-                            "DataSource" : {
-                                "Properties" : {
-                                    "ConsumerGroupName" : "",
-                                    "EventHubName" : "[reference(variables('iotHubResourceId')).eventHubEndpoints.events.path]",
-                                    "ServiceBusNamespace" : "[split(split(reference(variables('iotHubResourceId')).eventHubEndpoints.events.endpoint, '/')[2], '.')[0]]",
-                                    "SharedAccessPolicyKey" : "[listkeys(variables('iotHubKeyResource'), variables('iotHubVersion')).primaryKey]",
-                                    "SharedAccessPolicyName" : "[variables('iotHubKeyName')]"
+                    },
+                    {
+                        "Name": "IotTelemetryStream",
+                        "Properties": {
+                            "DataSource": {
+                                "Properties": {
+                                    "ConsumerGroupName": "[variables('rulesCGName')]",
+                                    "EventHubName": "[reference(variables('iotHubResourceId')).eventHubEndpoints.events.path]",
+                                    "ServiceBusNamespace": "[split(split(reference(variables('iotHubResourceId')).eventHubEndpoints.events.endpoint, '/')[2], '.')[0]]",
+                                    "SharedAccessPolicyKey": "[listkeys(variables('iotHubKeyResource'), variables('iotHubVersion')).primaryKey]",
+                                    "SharedAccessPolicyName": "[variables('iotHubKeyName')]"
                                 },
-                                "Type" : "Microsoft.ServiceBus/EventHub"
+                                "Type": "Microsoft.ServiceBus/EventHub"
                             },
-                            "Serialization" : {
-                                "Properties" : {
-                                    "Encoding" : "UTF8"
+                            "Serialization": {
+                                "Properties": {
+                                    "Encoding": "UTF8"
                                 },
-                                "Type" : "Json"
+                                "Type": "Json"
                             },
-                            "Type" : "Stream"
+                            "Type": "Stream"
                         }
                     }
                 ],
-                "Outputs" : [{
-                        "Name" : "DeviceRulesHub",
-                        "Properties" : {
-                            "DataSource" : {
-                                "Properties" : {
-                                    "EventHubName" : "[variables('ehRuleOutName')]",
-                                    "ServiceBusNamespace" : "[variables('sbName')]",
-                                    "SharedAccessPolicyKey" : "[listkeys(variables('sbResourceId'), variables('sbVersion')).primaryKey]",
-                                    "SharedAccessPolicyName" : "[variables('sbKeyName')]",
-                                    "PartitionKey" : "PartitionId"
+                "Outputs": [
+                    {
+                        "Name": "DeviceRulesHub",
+                        "Properties": {
+                            "DataSource": {
+                                "Properties": {
+                                    "EventHubName": "[variables('ehRuleOutName')]",
+                                    "ServiceBusNamespace": "[variables('sbName')]",
+                                    "SharedAccessPolicyKey": "[listkeys(variables('sbResourceId'), variables('sbVersion')).primaryKey]",
+                                    "SharedAccessPolicyName": "[variables('sbKeyName')]",
+                                    "PartitionKey": "PartitionId"
                                 },
-                                "Type" : "Microsoft.ServiceBus/EventHub"
+                                "Type": "Microsoft.ServiceBus/EventHub"
                             },
-                            "Serialization" : {
-                                "Properties" : {
-                                    "Encoding" : "UTF8",
-                                    "Format" : "Array"
+                            "Serialization": {
+                                "Properties": {
+                                    "Encoding": "UTF8",
+                                    "Format": "Array"
                                 },
-                                "Type" : "Json"
+                                "Type": "Json"
                             }
                         }
-                    }, {
-                        "Name" : "DeviceRulesMonitoring",
-                        "Properties" : {
-                            "DataSource" : {
-                                "Properties" : {
-                                    "Container" : "rulesoutput",
-                                    "DateFormat" : "yyyy/MM/dd",
-                                    "TimeFormat" : "HH",
-                                    "PathPattern" : "{date}/{time}",
-                                    "StorageAccounts" : [{
-                                            "AccountKey" : "[listkeys(variables('storageId'), variables('storageVersion')).key1]",
-                                            "AccountName" : "[variables('storageName')]"
+                    },
+                    {
+                        "Name": "DeviceRulesMonitoring",
+                        "Properties": {
+                            "DataSource": {
+                                "Properties": {
+                                    "Container": "rulesoutput",
+                                    "DateFormat": "yyyy/MM/dd",
+                                    "TimeFormat": "HH",
+                                    "PathPattern": "{date}/{time}",
+                                    "StorageAccounts": [
+                                        {
+                                            "AccountKey": "[listkeys(variables('storageId'), variables('storageVersion')).key1]",
+                                            "AccountName": "[variables('storageName')]"
                                         }
                                     ]
                                 },
-                                "Type" : "Microsoft.Storage/Blob"
+                                "Type": "Microsoft.Storage/Blob"
                             },
-                            "Serialization" : {
-                                "Properties" : {
-                                    "Encoding" : "UTF8",
-                                    "FieldDelimiter" : ","
+                            "Serialization": {
+                                "Properties": {
+                                    "Encoding": "UTF8",
+                                    "FieldDelimiter": ","
                                 },
-                                "Type" : "Csv"
+                                "Type": "Csv"
                             }
                         }
                     }
                 ],
-                "Transformation" : {
-                    "Name" : "DeviceRules",
-                    "Properties" : {
-                        "Query" : "WITH AlarmsData AS ( SELECT Stream.DeviceID, Stream.Temperature as TempReading, Ref.Temperature as TempThreshold, Stream.Humidity as HumidityReading, Ref.Humidity as HumidityThreshold, Ref.TemperatureRuleOutput, Ref.HumidityRuleOutput, Stream.EventEnqueuedUtcTime AS [Time] FROM IoTTelemetryStream Stream JOIN DeviceRulesBlob Ref ON Stream.DeviceID = Ref.DeviceID WHERE (Ref.Humidity IS NOT null AND Stream.Humidity > Ref.Humidity) OR (Ref.Temperature IS NOT null AND Stream.Temperature > Ref.Temperature) ) SELECT * INTO DeviceRulesMonitoring FROM AlarmsData SELECT * INTO DeviceRulesHub FROM AlarmsData",
-                        "StreamingUnits" : 1
+                "Transformation": {
+                    "Name": "DeviceRules",
+                    "Properties": {
+                        "Query": "WITH AlarmsData AS ( SELECT Stream.DeviceID, Stream.Temperature as TempReading, Ref.Temperature as TempThreshold, Stream.Humidity as HumidityReading, Ref.Humidity as HumidityThreshold, Ref.TemperatureRuleOutput, Ref.HumidityRuleOutput, Stream.EventEnqueuedUtcTime AS [Time] FROM IoTTelemetryStream Stream JOIN DeviceRulesBlob Ref ON Stream.DeviceID = Ref.DeviceID WHERE (Ref.Humidity IS NOT null AND Stream.Humidity > Ref.Humidity) OR (Ref.Temperature IS NOT null AND Stream.Temperature > Ref.Temperature) ) SELECT * INTO DeviceRulesMonitoring FROM AlarmsData SELECT * INTO DeviceRulesHub FROM AlarmsData",
+                        "StreamingUnits": 1
                     }
                 }
             }
-        }, {
-            "apiVersion" : "[variables('webVersion')]",
-            "name" : "[variables('webPlanName')]",
-            "type" : "Microsoft.Web/serverfarms",
-            "location" : "[variables('location')]",
-            "properties" : {
-                "name" : "[variables('webPlanName')]",
-                "sku" : "[variables('webSku')]",
-                "workerSize" : "[variables('webWorkerSize')]",
-                "numberOfWorkers" : "[variables('webWorkerCount')]"
+        },
+        {
+            "apiVersion": "[variables('webVersion')]",
+            "name": "[variables('webPlanName')]",
+            "type": "Microsoft.Web/serverfarms",
+            "location": "[variables('location')]",
+            "properties": {
+                "name": "[variables('webPlanName')]",
+                "sku": "[variables('webSku')]",
+                "workerSize": "[variables('webWorkerSize')]",
+                "numberOfWorkers": "[variables('webWorkerCount')]"
             }
-        }, {
-            "apiVersion" : "[variables('webVersion')]",
-            "name" : "[variables('webJobPlanName')]",
-            "type" : "Microsoft.Web/serverfarms",
-            "location" : "[variables('location')]",
-            "properties" : {
-                "name" : "[variables('webJobPlanName')]",
-                "sku" : "[variables('webJobSku')]",
-                "workerSize" : "[variables('webJobWorkerSize')]",
-                "numberOfWorkers" : "[variables('webJobWorkerCount')]"
-            }
-        }, {
-            "apiVersion" : "[variables('webVersion')]",
-            "name" : "[variables('webSiteName')]",
-            "type" : "Microsoft.Web/sites",
-            "location" : "[variables('location')]",
-            "dependsOn" : [
+        },
+        {
+            "apiVersion": "[variables('webVersion')]",
+            "name": "[variables('webJobPlanName')]",
+            "type": "Microsoft.Web/serverfarms",
+            "location": "[variables('location')]",
+            "properties": {
+                "name": "[variables('webJobPlanName')]",
+                "sku": "[variables('webJobSku')]",
+                "workerSize": "[variables('webJobWorkerSize')]",
+                "numberOfWorkers": "[variables('webJobWorkerCount')]"
+            },
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/serverfarms', variables('webPlanName'))]"
+            ]
+        },
+        {
+            "apiVersion": "[variables('webVersion')]",
+            "name": "[variables('webSiteName')]",
+            "type": "Microsoft.Web/sites",
+            "location": "[variables('location')]",
+            "dependsOn": [
                 "[resourceId('Microsoft.Web/serverfarms', variables('webPlanName'))]",
                 "[resourceId('Microsoft.Storage/storageAccounts', variables('storageName'))]",
                 "[resourceId('Microsoft.DocumentDb/databaseAccounts', variables('docDBName'))]",
                 "[resourceId('Microsoft.Devices/Iothubs', variables('name'))]",
                 "[resourceId('Microsoft.BingMaps/mapApis', variables('bingMapsName'))]"
             ],
-            "properties" : {
-                "serverFarmId" : "[variables('webPlanName')]",
-                "siteConfig" : {
-                    "AlwaysOn" : true,
-                    "appSettings" : [{
-                            "name" : "ida.AADTenant",
-                            "value" : "[parameters('AADTenant')]"
-                        }, {
-                            "name" : "ida.AADAudience",
-                            "value" : "[variables('AADRealm')]"
-                        }, {
-                            "name" : "ida.FederationMetadataAddress",
-                            "value" : "[variables('AADMetadataAddress')]"
-                        }, {
-                            "name" : "ida.FederationRealm",
-                            "value" : "[variables('AADRealm')]"
-                        }, {
-                            "name" : "docdb.EndpointUrl",
-                            "value" : "[reference(variables('docDBName')).documentEndpoint]"
-                        }, {
-                            "name" : "docdb.PrimaryAuthorizationKey",
-                            "value" : "[listkeys(variables('docDBName'), '2015-04-08').primaryMasterKey]"
-                        }, {
-                            "name" : "iotHub.HostName",
-                            "value" : "[reference(variables('iotHubResourceId')).hostName]"
-                        }, {
-                            "name" : "iotHub.ConnectionString",
-                            "value" : "[concat('HostName=', reference(variables('iotHubResourceId')).hostName, ';SharedAccessKeyName=', variables('iotHubKeyName'), ';SharedAccessKey=', listkeys(variables('iotHubKeyResource'), variables('iotHubVersion')).primaryKey)]"
-                        }, {
-                            "name" : "device.StorageConnectionString",
-                            "value" : "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageName'), ';AccountKey=', listkeys(variables('storageId'), variables('storageVersion')).key1)]"
-                        }, {
-                            "name" : "device.TableName",
-                            "value" : "DeviceList"
-                        }, {
-                            "name" : "eventHub.HubName",
-                            "value" : "[variables('ehOutName')]"
-                        }, {
-                            "name" : "eventHub.ConnectionString",
-                            "value" : "[listkeys(variables('sbResourceId'), variables('sbVersion')).primaryConnectionString]"
-                        }, {
-                            "name" : "eventHub.StorageConnectionString",
-                            "value" : "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageName'), ';AccountKey=', listkeys(variables('storageId'), variables('storageVersion')).key1)]"
-                        }, {
-                            "name" : "RulesEventHub.Name",
-                            "value" : "[variables('ehRuleOutName')]"
-                        }, {
-                            "name" : "RulesEventHub.ConnectionString",
-                            "value" : "[listkeys(variables('sbResourceId'), variables('sbVersion')).primaryConnectionString]"
-                        }, {
-                            "name" : "ObjectTypePrefix",
-                            "value" : ""
-                        }, {
-                            "name" : "MapApiQueryKey",
-                            "value" : "[listSecrets(variables('bingMapsName'), variables('bingMapsVersion')).QueryKey]"
-                        }, {
-                            "name" : "SolutionName",
-                            "value" : "[variables('name')]"
+            "properties": {
+                "serverFarmId": "[variables('webPlanName')]",
+                "siteConfig": {
+                    "AlwaysOn": true,
+                    "appSettings": [
+                        {
+                            "name": "ida.AADTenant",
+                            "value": "[parameters('AADTenant')]"
+                        },
+                        {
+                            "name": "ida.AADAudience",
+                            "value": "[variables('AADRealm')]"
+                        },
+                        {
+                            "name": "ida.FederationMetadataAddress",
+                            "value": "[variables('AADMetadataAddress')]"
+                        },
+                        {
+                            "name": "ida.FederationRealm",
+                            "value": "[variables('AADRealm')]"
+                        },
+                        {
+                            "name": "docdb.EndpointUrl",
+                            "value": "[reference(variables('docDBName')).documentEndpoint]"
+                        },
+                        {
+                            "name": "docdb.PrimaryAuthorizationKey",
+                            "value": "[listkeys(variables('docDBName'), '2015-04-08').primaryMasterKey]"
+                        },
+                        {
+                            "name": "iotHub.HostName",
+                            "value": "[reference(variables('iotHubResourceId')).hostName]"
+                        },
+                        {
+                            "name": "iotHub.ConnectionString",
+                            "value": "[concat('HostName=', reference(variables('iotHubResourceId')).hostName, ';SharedAccessKeyName=', variables('iotHubKeyName'), ';SharedAccessKey=', listkeys(variables('iotHubKeyResource'), variables('iotHubVersion')).primaryKey)]"
+                        },
+                        {
+                            "name": "device.StorageConnectionString",
+                            "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageName'), ';AccountKey=', listkeys(variables('storageId'), variables('storageVersion')).key1)]"
+                        },
+                        {
+                            "name": "device.TableName",
+                            "value": "DeviceList"
+                        },
+                        {
+                            "name": "eventHub.HubName",
+                            "value": "[variables('ehOutName')]"
+                        },
+                        {
+                            "name": "eventHub.ConnectionString",
+                            "value": "[listkeys(variables('sbResourceId'), variables('sbVersion')).primaryConnectionString]"
+                        },
+                        {
+                            "name": "eventHub.StorageConnectionString",
+                            "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageName'), ';AccountKey=', listkeys(variables('storageId'), variables('storageVersion')).key1)]"
+                        },
+                        {
+                            "name": "RulesEventHub.Name",
+                            "value": "[variables('ehRuleOutName')]"
+                        },
+                        {
+                            "name": "RulesEventHub.ConnectionString",
+                            "value": "[listkeys(variables('sbResourceId'), variables('sbVersion')).primaryConnectionString]"
+                        },
+                        {
+                            "name": "ObjectTypePrefix",
+                            "value": ""
+                        },
+                        {
+                            "name": "MapApiQueryKey",
+                            "value": "[listSecrets(variables('bingMapsName'), variables('bingMapsVersion')).QueryKey]"
+                        },
+                        {
+                            "name": "SolutionName",
+                            "value": "[variables('name')]"
                         }
                     ]
                 }
 
             },
-            "resources" : [{
-                    "apiVersion" : "[variables('webVersion')]",
-                    "name" : "MSDeploy",
-                    "type" : "extensions",
-                    "dependsOn" : [
+            "resources": [
+                {
+                    "apiVersion": "[variables('webVersion')]",
+                    "name": "MSDeploy",
+                    "type": "extensions",
+                    "dependsOn": [
                         "[resourceId('Microsoft.Web/Sites', variables('webSiteName'))]"
                     ],
-                    "properties" : {
-                        "packageUri" : "[parameters('packageUri')]",
-                        "connectionString" : "",
-                        "dbType" : ""
+                    "properties": {
+                        "packageUri": "[parameters('packageUri')]",
+                        "connectionString": "",
+                        "dbType": ""
                     }
                 }
             ]
-        }, {
-            "apiVersion" : "[variables('webVersion')]",
-            "name" : "[variables('webJobSiteName')]",
-            "type" : "Microsoft.Web/sites",
-            "location" : "[variables('location')]",
-            "dependsOn" : [
+        },
+        {
+            "apiVersion": "[variables('webVersion')]",
+            "name": "[variables('webJobSiteName')]",
+            "type": "Microsoft.Web/sites",
+            "location": "[variables('location')]",
+            "dependsOn": [
                 "[resourceId('Microsoft.Web/serverfarms', variables('webJobPlanName'))]",
-                "[resourceId('Microsoft.Web/sites', variables('webSiteName'))]"
+                "[resourceId('Microsoft.Storage/storageAccounts', variables('storageName'))]",
+                "[resourceId('Microsoft.DocumentDb/databaseAccounts', variables('docDBName'))]",
+                "[resourceId('Microsoft.Devices/Iothubs', variables('name'))]",
+                "[resourceId('Microsoft.BingMaps/mapApis', variables('bingMapsName'))]"
             ],
-            "properties" : {
-                "serverFarmId" : "[variables('webJobPlanName')]",
-                "siteConfig" : {
-                    "AlwaysOn" : true,
-                    "appSettings" : [{
-                            "name" : "ida.AADTenant",
-                            "value" : "[parameters('AADTenant')]"
-                        }, {
-                            "name" : "ida.AADAudience",
-                            "value" : "[variables('AADRealm')]"
-                        }, {
-                            "name" : "ida.FederationMetadataAddress",
-                            "value" : "[variables('AADMetadataAddress')]"
-                        }, {
-                            "name" : "ida.FederationRealm",
-                            "value" : "[variables('AADRealm')]"
-                        }, {
-                            "name" : "docdb.EndpointUrl",
-                            "value" : "[reference(variables('docDBName')).documentEndpoint]"
-                        }, {
-                            "name" : "docdb.PrimaryAuthorizationKey",
-                            "value" : "[listkeys(variables('docDBName'), '2015-04-08').primaryMasterKey]"
-                        }, {
-                            "name" : "iotHub.HostName",
-                            "value" : "[reference(variables('iotHubResourceId')).hostName]"
-                        }, {
-                            "name" : "iotHub.ConnectionString",
-                            "value" : "[concat('HostName=', reference(variables('iotHubResourceId')).hostName, ';SharedAccessKeyName=', variables('iotHubKeyName'), ';SharedAccessKey=', listkeys(variables('iotHubKeyResource'), variables('iotHubVersion')).primaryKey)]"
-                        }, {
-                            "name" : "device.StorageConnectionString",
-                            "value" : "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageName'), ';AccountKey=', listkeys(variables('storageId'), variables('storageVersion')).key1)]"
-                        }, {
-                            "name" : "device.TableName",
-                            "value" : "DeviceList"
-                        }, {
-                            "name" : "eventHub.HubName",
-                            "value" : "[variables('ehOutName')]"
-                        }, {
-                            "name" : "eventHub.ConnectionString",
-                            "value" : "[listkeys(variables('sbResourceId'), variables('sbVersion')).primaryConnectionString]"
-                        }, {
-                            "name" : "eventHub.StorageConnectionString",
-                            "value" : "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageName'), ';AccountKey=', listkeys(variables('storageId'), variables('storageVersion')).key1)]"
-                        }, {
-                            "name" : "RulesEventHub.Name",
-                            "value" : "[variables('ehRuleOutName')]"
-                        }, {
-                            "name" : "RulesEventHub.ConnectionString",
-                            "value" : "[listkeys(variables('sbResourceId'), variables('sbVersion')).primaryConnectionString]"
-                        }, {
-                            "name" : "ObjectTypePrefix",
-                            "value" : ""
-                        }, {
-                            "name" : "MapApiQueryKey",
-                            "value" : "[listSecrets(variables('bingMapsName'), variables('bingMapsVersion')).QueryKey]"
-                        }, {
-                            "name" : "SolutionName",
-                            "value" : "[variables('name')]"
+            "properties": {
+                "serverFarmId": "[variables('webJobPlanName')]",
+                "siteConfig": {
+                    "AlwaysOn": true,
+                    "appSettings": [
+                        {
+                            "name": "ida.AADTenant",
+                            "value": "[parameters('AADTenant')]"
+                        },
+                        {
+                            "name": "ida.AADAudience",
+                            "value": "[variables('AADRealm')]"
+                        },
+                        {
+                            "name": "ida.FederationMetadataAddress",
+                            "value": "[variables('AADMetadataAddress')]"
+                        },
+                        {
+                            "name": "ida.FederationRealm",
+                            "value": "[variables('AADRealm')]"
+                        },
+                        {
+                            "name": "docdb.EndpointUrl",
+                            "value": "[reference(variables('docDBName')).documentEndpoint]"
+                        },
+                        {
+                            "name": "docdb.PrimaryAuthorizationKey",
+                            "value": "[listkeys(variables('docDBName'), '2015-04-08').primaryMasterKey]"
+                        },
+                        {
+                            "name": "iotHub.HostName",
+                            "value": "[reference(variables('iotHubResourceId')).hostName]"
+                        },
+                        {
+                            "name": "iotHub.ConnectionString",
+                            "value": "[concat('HostName=', reference(variables('iotHubResourceId')).hostName, ';SharedAccessKeyName=', variables('iotHubKeyName'), ';SharedAccessKey=', listkeys(variables('iotHubKeyResource'), variables('iotHubVersion')).primaryKey)]"
+                        },
+                        {
+                            "name": "device.StorageConnectionString",
+                            "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageName'), ';AccountKey=', listkeys(variables('storageId'), variables('storageVersion')).key1)]"
+                        },
+                        {
+                            "name": "device.TableName",
+                            "value": "DeviceList"
+                        },
+                        {
+                            "name": "eventHub.HubName",
+                            "value": "[variables('ehOutName')]"
+                        },
+                        {
+                            "name": "eventHub.ConnectionString",
+                            "value": "[listkeys(variables('sbResourceId'), variables('sbVersion')).primaryConnectionString]"
+                        },
+                        {
+                            "name": "eventHub.StorageConnectionString",
+                            "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageName'), ';AccountKey=', listkeys(variables('storageId'), variables('storageVersion')).key1)]"
+                        },
+                        {
+                            "name": "RulesEventHub.Name",
+                            "value": "[variables('ehRuleOutName')]"
+                        },
+                        {
+                            "name": "RulesEventHub.ConnectionString",
+                            "value": "[listkeys(variables('sbResourceId'), variables('sbVersion')).primaryConnectionString]"
+                        },
+                        {
+                            "name": "ObjectTypePrefix",
+                            "value": ""
+                        },
+                        {
+                            "name": "MapApiQueryKey",
+                            "value": "[listSecrets(variables('bingMapsName'), variables('bingMapsVersion')).QueryKey]"
+                        },
+                        {
+                            "name": "SolutionName",
+                            "value": "[variables('name')]"
                         }
                     ]
                 }
 
             },
-            "resources" : [{
-                    "apiVersion" : "[variables('webVersion')]",
-                    "name" : "MSDeploy",
-                    "type" : "extensions",
-                    "dependsOn" : [
+            "resources": [
+                {
+                    "apiVersion": "[variables('webVersion')]",
+                    "name": "MSDeploy",
+                    "type": "extensions",
+                    "dependsOn": [
                         "[resourceId('Microsoft.Web/Sites', variables('webJobSiteName'))]"
                     ],
-                    "properties" : {
-                        "packageUri" : "[parameters('webJobPackageUri')]",
-                        "connectionString" : "",
-                        "dbType" : ""
+                    "properties": {
+                        "packageUri": "[parameters('webJobPackageUri')]",
+                        "connectionString": "",
+                        "dbType": ""
                     }
                 }
             ]
         }
     ],
-    "outputs" : {
-        "Region" : {
-            "type" : "string",
-            "value" : "[variables('location')]"
+    "outputs": {
+        "Region": {
+            "type": "string",
+            "value": "[variables('location')]"
         },
-        "IotHubConnectionString" : {
-            "type" : "string",
-            "value" : "[concat('HostName=', reference(variables('iotHubResourceId')).hostName, ';SharedAccessKeyName=', variables('iotHubKeyName'), ';SharedAccessKey=', listkeys(variables('iotHubKeyResource'), variables('iotHubVersion')).primaryKey)]"
+        "IotHubConnectionString": {
+            "type": "string",
+            "value": "[concat('HostName=', reference(variables('iotHubResourceId')).hostName, ';SharedAccessKeyName=', variables('iotHubKeyName'), ';SharedAccessKey=', listkeys(variables('iotHubKeyResource'), variables('iotHubVersion')).primaryKey)]"
         },
-        "EventHubConnectionString" : {
-            "type" : "string",
-            "value" : "[concat('EndPoint=', reference(variables('iotHubResourceId')).eventHubEndpoints.events.endpoint, ';SharedAccessKeyName=', variables('iotHubKeyName'), ';SharedAccessKey=', listkeys(variables('iotHubKeyResource'), variables('iotHubVersion')).primaryKey)]"
+        "EventHubConnectionString": {
+            "type": "string",
+            "value": "[concat('EndPoint=', reference(variables('iotHubResourceId')).eventHubEndpoints.events.endpoint, ';SharedAccessKeyName=', variables('iotHubKeyName'), ';SharedAccessKey=', listkeys(variables('iotHubKeyResource'), variables('iotHubVersion')).primaryKey)]"
         },
-        "EventHubName" : {
-            "type" : "string",
-            "value" : "[reference(variables('iotHubResourceId')).eventHubEndpoints.events.path]"
+        "EventHubName": {
+            "type": "string",
+            "value": "[reference(variables('iotHubResourceId')).eventHubEndpoints.events.path]"
         },
-        "DocDbURI" : {
-            "type" : "string",
-            "value" : "[reference(variables('docDBName')).documentEndpoint]"
+        "DocDbURI": {
+            "type": "string",
+            "value": "[reference(variables('docDBName')).documentEndpoint]"
         },
-        "DocDbKey" : {
-            "type" : "string",
-            "value" : "[listkeys(variables('docDBName'), '2015-04-08').primaryMasterKey]"
+        "DocDbKey": {
+            "type": "string",
+            "value": "[listkeys(variables('docDBName'), '2015-04-08').primaryMasterKey]"
         },
-        "BingMapsQueryKey" : {
-            "type" : "string",
-            "value" : "[listSecrets(variables('bingMapsName'), variables('bingMapsVersion')).QueryKey]"
+        "BingMapsQueryKey": {
+            "type": "string",
+            "value": "[listSecrets(variables('bingMapsName'), variables('bingMapsVersion')).QueryKey]"
         }
     }
 }

--- a/Common/Deployment/RemoteMonitoring.json
+++ b/Common/Deployment/RemoteMonitoring.json
@@ -11,6 +11,10 @@
         "packageUri" : {
             "type" : "string",
             "defaultValue" : "http://aka.ms/azureiot/remotemonitoring"
+        },
+        "webJobPackageUri" : {
+            "type" : "string",
+            "defaultValue" : "http://aka.ms/azureiot/remotemonitoring/webjob"
         }
     },
     "variables" : {
@@ -30,11 +34,16 @@
         "webVersion" : "2015-04-01",
         "bingMapsName" : "[concat(variables('name'), '-map')]",
         "bingMapsVersion" : "2015-07-02",
-        "webPlanName" : "[concat(variables('name'), '-plan')]",
-        "webSiteName" : "[variables('name')]",
+        "webJobPlanName": "[concat(variables('name'), '-jobs-plan')]",
+        "webJobSku" : "Basic",
+        "webJobWorkerSize" : "0",
+        "webJobWorkerCount": "2",
+        "webJobSiteName": "[concat(variables('name'), '-jobhost')]",
+        "webPlanName": "[concat(variables('name'), '-plan')]",
+        "webSiteName": "[variables('name')]",
         "webSku" : "Basic",
         "webWorkerSize" : "0",
-        "webWorkerCount" : "1",
+        "webWorkerCount" : "2",
         "AADMetadataAddress" : "[concat('https://login.windows.net/' , parameters('AADTenant'), '/FederationMetadata/2007-06/FederationMetadata.xml')]",
         "AADRealm" : "[toLower(concat('https://', variables('webSiteName'), '.azurewebsites.net/iotsuite'))]",
         "docDBVersion" : "2015-04-08",
@@ -422,6 +431,17 @@
             }
         }, {
             "apiVersion" : "[variables('webVersion')]",
+            "name" : "[variables('webJobPlanName')]",
+            "type" : "Microsoft.Web/serverfarms",
+            "location" : "[variables('location')]",
+            "properties" : {
+                "name" : "[variables('webJobPlanName')]",
+                "sku" : "[variables('webJobSku')]",
+                "workerSize" : "[variables('webJobWorkerSize')]",
+                "numberOfWorkers" : "[variables('webJobWorkerCount')]"
+            }
+        }, {
+            "apiVersion" : "[variables('webVersion')]",
             "name" : "[variables('webSiteName')]",
             "type" : "Microsoft.Web/sites",
             "location" : "[variables('location')]",
@@ -504,6 +524,92 @@
                     ],
                     "properties" : {
                         "packageUri" : "[parameters('packageUri')]",
+                        "connectionString" : "",
+                        "dbType" : ""
+                    }
+                }
+            ]
+        }, {
+            "apiVersion" : "[variables('webVersion')]",
+            "name" : "[variables('webJobSiteName')]",
+            "type" : "Microsoft.Web/sites",
+            "location" : "[variables('location')]",
+            "dependsOn" : [
+                "[resourceId('Microsoft.Web/serverfarms', variables('webJobPlanName'))]",
+                "[resourceId('Microsoft.Web/sites', variables('webSiteName'))]"
+            ],
+            "properties" : {
+                "serverFarmId" : "[variables('webJobPlanName')]",
+                "siteConfig" : {
+                    "AlwaysOn" : true,
+                    "appSettings" : [{
+                            "name" : "ida.AADTenant",
+                            "value" : "[parameters('AADTenant')]"
+                        }, {
+                            "name" : "ida.AADAudience",
+                            "value" : "[variables('AADRealm')]"
+                        }, {
+                            "name" : "ida.FederationMetadataAddress",
+                            "value" : "[variables('AADMetadataAddress')]"
+                        }, {
+                            "name" : "ida.FederationRealm",
+                            "value" : "[variables('AADRealm')]"
+                        }, {
+                            "name" : "docdb.EndpointUrl",
+                            "value" : "[reference(variables('docDBName')).documentEndpoint]"
+                        }, {
+                            "name" : "docdb.PrimaryAuthorizationKey",
+                            "value" : "[listkeys(variables('docDBName'), '2015-04-08').primaryMasterKey]"
+                        }, {
+                            "name" : "iotHub.HostName",
+                            "value" : "[reference(variables('iotHubResourceId')).hostName]"
+                        }, {
+                            "name" : "iotHub.ConnectionString",
+                            "value" : "[concat('HostName=', reference(variables('iotHubResourceId')).hostName, ';SharedAccessKeyName=', variables('iotHubKeyName'), ';SharedAccessKey=', listkeys(variables('iotHubKeyResource'), variables('iotHubVersion')).primaryKey)]"
+                        }, {
+                            "name" : "device.StorageConnectionString",
+                            "value" : "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageName'), ';AccountKey=', listkeys(variables('storageId'), variables('storageVersion')).key1)]"
+                        }, {
+                            "name" : "device.TableName",
+                            "value" : "DeviceList"
+                        }, {
+                            "name" : "eventHub.HubName",
+                            "value" : "[variables('ehOutName')]"
+                        }, {
+                            "name" : "eventHub.ConnectionString",
+                            "value" : "[listkeys(variables('sbResourceId'), variables('sbVersion')).primaryConnectionString]"
+                        }, {
+                            "name" : "eventHub.StorageConnectionString",
+                            "value" : "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageName'), ';AccountKey=', listkeys(variables('storageId'), variables('storageVersion')).key1)]"
+                        }, {
+                            "name" : "RulesEventHub.Name",
+                            "value" : "[variables('ehRuleOutName')]"
+                        }, {
+                            "name" : "RulesEventHub.ConnectionString",
+                            "value" : "[listkeys(variables('sbResourceId'), variables('sbVersion')).primaryConnectionString]"
+                        }, {
+                            "name" : "ObjectTypePrefix",
+                            "value" : ""
+                        }, {
+                            "name" : "MapApiQueryKey",
+                            "value" : "[listSecrets(variables('bingMapsName'), variables('bingMapsVersion')).QueryKey]"
+                        }, {
+                            "name" : "SolutionName",
+                            "value" : "[variables('name')]"
+                        }
+                    ]
+                }
+
+            },
+            "resources" : [{
+                    "apiVersion" : "[variables('webVersion')]",
+                    "name" : "MSDeploy",
+                    "type" : "extensions",
+                    "dependsOn" : [
+                        "[resourceId('Microsoft.Web/Sites', variables('webJobSiteName'))]"
+                    ],
+                    "properties" : {
+                        "packageUri" : "[parameters('webJobPackageUri')]",
                         "connectionString" : "",
                         "dbType" : ""
                     }

--- a/DeviceAdministration/Web/Web.csproj
+++ b/DeviceAdministration/Web/Web.csproj
@@ -415,7 +415,6 @@
     <Content Include="Content\screen.css.map">
       <DependentUpon>screen.css</DependentUpon>
     </Content>
-    <Content Include="Properties\webjobs-list.json" />
     <None Include="Scripts\jquery-1.11.2.intellisense.js" />
     <Content Include="Scripts\IoTHelperScripts.js" />
     <Content Include="Scripts\jquery-1.11.2.js" />

--- a/RemoteMonitoring.sln
+++ b/RemoteMonitoring.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+VisualStudioVersion = 12.0.40629.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Common", "Common\Common.csproj", "{5959C109-5369-4FF7-8B55-605A79FDF200}"
 EndProject
@@ -23,6 +23,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Infrastructure.UnitTests", "DeviceAdministration\Infrastructure.UnitTests\Infrastructure.UnitTests.csproj", "{008E8267-1703-4108-904A-99C1B9ED8F7A}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebJob", "DeviceAdministration\WebJob\WebJob.csproj", "{8F9CAF4E-8537-4398-A1C2-C39CC4136B69}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebJobHost", "WebJobHost\WebJobHost.csproj", "{350C5961-0778-45F8-9A59-D309FCD653DD}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -58,6 +60,10 @@ Global
 		{8F9CAF4E-8537-4398-A1C2-C39CC4136B69}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8F9CAF4E-8537-4398-A1C2-C39CC4136B69}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8F9CAF4E-8537-4398-A1C2-C39CC4136B69}.Release|Any CPU.Build.0 = Release|Any CPU
+		{350C5961-0778-45F8-9A59-D309FCD653DD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{350C5961-0778-45F8-9A59-D309FCD653DD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{350C5961-0778-45F8-9A59-D309FCD653DD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{350C5961-0778-45F8-9A59-D309FCD653DD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/WebJobHost/Properties/AssemblyInfo.cs
+++ b/WebJobHost/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("WebJobHost")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Microsoft")]
+[assembly: AssemblyProduct("Azure Remote Monitoring Solution")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("7a06b2bb-cab3-4a1a-a9cc-c4696a61091e")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Revision and Build Numbers 
+// by using the '*' as shown below:
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/WebJobHost/Properties/webjobs-list.json
+++ b/WebJobHost/Properties/webjobs-list.json
@@ -2,7 +2,7 @@
   "$schema": "http://schemastore.org/schemas/json/webjobs-list.json",
   "WebJobs": [
     {
-      "filePath": "../WebJob/WebJob.csproj"
+      "filePath": "../DeviceAdministration/WebJob/WebJob.csproj"
     }
   ]
 }

--- a/WebJobHost/Web.Debug.config
+++ b/WebJobHost/Web.Debug.config
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- For more information on using web.config transformation visit http://go.microsoft.com/fwlink/?LinkId=125889 -->
+
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <!--
+    In the example below, the "SetAttributes" transform will change the value of 
+    "connectionString" to use "ReleaseSQLServer" only when the "Match" locator 
+    finds an attribute "name" that has a value of "MyDB".
+    
+    <connectionStrings>
+      <add name="MyDB" 
+        connectionString="Data Source=ReleaseSQLServer;Initial Catalog=MyReleaseDB;Integrated Security=True" 
+        xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
+    </connectionStrings>
+  -->
+  <system.web>
+    <!--
+      In the example below, the "Replace" transform will replace the entire 
+      <customErrors> section of your web.config file.
+      Note that because there is only one customErrors section under the 
+      <system.web> node, there is no need to use the "xdt:Locator" attribute.
+      
+      <customErrors defaultRedirect="GenericError.htm"
+        mode="RemoteOnly" xdt:Transform="Replace">
+        <error statusCode="500" redirect="InternalError.htm"/>
+      </customErrors>
+    -->
+  </system.web>
+</configuration>

--- a/WebJobHost/Web.Release.config
+++ b/WebJobHost/Web.Release.config
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- For more information on using web.config transformation visit http://go.microsoft.com/fwlink/?LinkId=125889 -->
+
+<configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
+  <!--
+    In the example below, the "SetAttributes" transform will change the value of 
+    "connectionString" to use "ReleaseSQLServer" only when the "Match" locator 
+    finds an attribute "name" that has a value of "MyDB".
+    
+    <connectionStrings>
+      <add name="MyDB" 
+        connectionString="Data Source=ReleaseSQLServer;Initial Catalog=MyReleaseDB;Integrated Security=True" 
+        xdt:Transform="SetAttributes" xdt:Locator="Match(name)"/>
+    </connectionStrings>
+  -->
+  <system.web>
+    <compilation xdt:Transform="RemoveAttributes(debug)" />
+    <!--
+      In the example below, the "Replace" transform will replace the entire 
+      <customErrors> section of your web.config file.
+      Note that because there is only one customErrors section under the 
+      <system.web> node, there is no need to use the "xdt:Locator" attribute.
+      
+      <customErrors defaultRedirect="GenericError.htm"
+        mode="RemoteOnly" xdt:Transform="Replace">
+        <error statusCode="500" redirect="InternalError.htm"/>
+      </customErrors>
+    -->
+  </system.web>
+</configuration>

--- a/WebJobHost/Web.config
+++ b/WebJobHost/Web.config
@@ -1,0 +1,77 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+  For more information on how to configure your ASP.NET application, please visit
+  http://go.microsoft.com/fwlink/?LinkId=169433
+  -->
+<configuration>
+  <system.web>
+    <compilation debug="true" targetFramework="4.5" />
+    <httpRuntime targetFramework="4.5" />
+  </system.web>
+  <appSettings>
+    <add key="ida.AADTenant" value="config:AADTenant" />
+    <add key="ida.AADAudience" value="config:AADAudience" />
+    <add key="ida.FederationMetadataAddress" value="config:AADMetadataAddress" />
+    <add key="ida.FederationRealm" value="config:AADRealm" />
+    <add key="docdb.EndpointUrl" value="config:DocDbEndPoint" />
+    <add key="docdb.PrimaryAuthorizationKey" value="config:DocDBKey" />
+    <add key="docdb.DatabaseId" value="DevMgmtDB" />
+    <add key="docdb.DocumentCollectionId" value="DevMgmtCollection" />
+    <add key="iotHub.HostName" value="config:IotHubName" />
+    <add key="iotHub.ConnectionString" value="config:IotHubConnectionString" />
+    <add key="device.StorageConnectionString" value="config:ServiceStoreAccountConnectionString" />
+    <add key="device.TableName" value="config:DeviceTableName" />
+    <add key="DeviceRulesStoreContainerName" value="devicerules" />
+    <add key="DeviceRulesTableName" value="DeviceRulesNormalizedTable" />
+    <add key="ActionMappingStoreContainerName" value="actionmappings" />
+    <add key="ActionMappingStoreBlobName" value="mappings.json" />
+    <add key="AsaRefDataRulesBlobName" value="devicerules.json" />
+    <add key="SolutionName" value="Remote Monitoring Solution" />
+    <add key="TelemetryStoreContainerName" value="devicetelemetry" />
+    <add key="TelemetryDataPrefix" value="devicetelemetry/" />
+    <add key="TelemetrySummaryPrefix" value="devicetelemetry-summary/" />
+    <add key="AlertsStoreContainerName" value="rulesoutput" />
+    <add key="DeviceAlertsDataPrefix" value="" />
+    <add key="MapApiQueryKey" value="config:MapApiQueryKey" />
+  </appSettings>
+
+  <system.web>
+    <compilation debug="true" targetFramework="4.5.1" />
+    <httpRuntime targetFramework="4.5" />
+    <globalization culture="auto" uiCulture="auto" enableClientBasedCulture="true" />
+    <customErrors mode="RemoteOnly" />
+    <sessionState mode="Off" />
+  </system.web>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.WindowsAzure.ServiceRuntime" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.2.0" newVersion="5.0.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.1.0" newVersion="3.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Http.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/WebJobHost/WebJobHost.csproj
+++ b/WebJobHost/WebJobHost.csproj
@@ -1,0 +1,126 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>
+    </ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{350C5961-0778-45F8-9A59-D309FCD653DD}</ProjectGuid>
+    <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>WebJobHost</RootNamespace>
+    <AssemblyName>WebJobHost</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <UseIISExpress>true</UseIISExpress>
+    <IISExpressSSLPort />
+    <IISExpressAnonymousAuthentication />
+    <IISExpressWindowsAuthentication />
+    <IISExpressUseClassicPipelineMode />
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Web.DynamicData" />
+    <Reference Include="System.Web.Entity" />
+    <Reference Include="System.Web.ApplicationServices" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Web.Extensions" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Web.Services" />
+    <Reference Include="System.EnterpriseServices" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Properties\webjobs-list.json" />
+    <Content Include="packages.config" />
+    <None Include="Web.Debug.config">
+      <DependentUpon>Web.config</DependentUpon>
+    </None>
+    <None Include="Web.Release.config">
+      <DependentUpon>Web.config</DependentUpon>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="Web.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DeviceAdministration\WebJob\WebJob.csproj">
+      <Project>{8f9caf4e-8537-4398-a1c2-c39cc4136b69}</Project>
+      <Name>WebJob</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(VSToolsPath)\WebApplications\Microsoft.WebApplication.targets" Condition="'$(VSToolsPath)' != ''" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="false" />
+  <Target Name="MvcBuildViews" AfterTargets="AfterBuild" Condition="'$(MvcBuildViews)'=='true'">
+    <AspNetCompiler VirtualPath="temp" PhysicalPath="$(WebProjectOutputDir)" />
+  </Target>
+  <ProjectExtensions>
+    <VisualStudio>
+      <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
+        <WebProjectProperties>
+          <UseIIS>True</UseIIS>
+          <AutoAssignPort>True</AutoAssignPort>
+          <DevelopmentServerPort>37386</DevelopmentServerPort>
+          <DevelopmentServerVPath>/</DevelopmentServerVPath>
+          <IISUrl>http://localhost:37386/</IISUrl>
+          <NTLMAuthentication>False</NTLMAuthentication>
+          <UseCustomServer>False</UseCustomServer>
+          <CustomServerUrl>
+          </CustomServerUrl>
+          <SaveServerSettingsInUserFile>False</SaveServerSettingsInUserFile>
+        </WebProjectProperties>
+      </FlavorProperties>
+    </VisualStudio>
+  </ProjectExtensions>
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+  </Target>
+  <Import Project="..\packages\Microsoft.Web.WebJobs.Publish.1.0.3\tools\webjobs.targets" Condition="Exists('..\packages\Microsoft.Web.WebJobs.Publish.1.0.3\tools\webjobs.targets')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/WebJobHost/packages.config
+++ b/WebJobHost/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Web.WebJobs.Publish" version="1.0.3" targetFramework="net45" />
+</packages>

--- a/build.cmd
+++ b/build.cmd
@@ -66,6 +66,7 @@
     rmdir /s /q Build_Output)
 msbuild RemoteMonitoring.sln /v:m /p:Configuration=%Configuration%
 msbuild DeviceAdministration\Web\Web.csproj /v:m /T:Package /P:VisualStudioVersion=12.0 /p:OutputPath=%~dp0Build_Output\
+msbuild WebJobHost\WebJobHost.csproj /v:m /T:Package /P:VisualStudioVersion=12.0 /p:OutputPath=%~dp0Build_Output\
 @IF /I '%ERRORLEVEL%' NEQ '0' (
     @echo Error msbuild IoTRefImplementation.sln /v:m /t:publish /p:Configuration=%Configuration%
     @goto :Error


### PR DESCRIPTION
Due to formatting changes it looks like the whole template changed, but there are only two important changes here:

1. Added the creation of 3 consumer groups to IoTHub and referenced the groups from the ASA jobs.
2. Split out the WebJobs into its own server farm so it can be scaled separately. This will require a deployment package update once the pull request is accepted.