### PR TITLE
Vertigo davidb address alerts schema issues

### DIFF
--- a/Common/Helpers/ReflectionHelper.cs
+++ b/Common/Helpers/ReflectionHelper.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Dynamic;
 using System.Linq;
 using System.Reflection;
+using Microsoft.CSharp.RuntimeBinder;
 using D = Dynamitey;
 
 namespace Microsoft.Azure.Devices.Applications.RemoteMonitoring.Common.Helpers
@@ -162,7 +163,14 @@ namespace Microsoft.Azure.Devices.Applications.RemoteMonitoring.Common.Helpers
                 }
             }
 
-            return D.Dynamic.InvokeGet(item, propertyName);
+            try
+            {
+                return D.Dynamic.InvokeGet(item, propertyName);
+            }
+            catch (RuntimeBinderException)
+            {
+                return null;
+            }
         }
 
         // <summary>


### PR DESCRIPTION
Fix an issue where missing property threw an unhandled exception. 

This was causing an upgrade scenario to fail to populate rules data (due to inability to parse outdated rules ASA job output).