### PR TITLE
make REST DB util generic

### DIFF
--- a/Common/Common.csproj
+++ b/Common/Common.csproj
@@ -113,6 +113,7 @@
     <Compile Include="Helpers\AzureRetryHelper.cs" />
     <Compile Include="Helpers\AzureTableStorageHelper.cs" />
     <Compile Include="Helpers\BlobStorageHelper.cs" />
+    <Compile Include="Schema\SchemaHelper.cs" />
     <Compile Include="Utility\DocDbQueryResult.cs" />
     <Compile Include="Helpers\DynamicValuesHelper.cs" />
     <Compile Include="Helpers\FunctionalHelper.cs" />

--- a/Common/DeviceSchema/DeviceSchemaHelper.cs
+++ b/Common/DeviceSchema/DeviceSchemaHelper.cs
@@ -1,15 +1,16 @@
 ﻿using System;
 using Microsoft.Azure.Devices.Applications.RemoteMonitoring.Common.Exceptions;
 using Microsoft.Azure.Devices.Applications.RemoteMonitoring.Common.Models;
+using Microsoft.Azure.Devices.Applications.RemoteMonitoring.Common.Schema;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Azure.Devices.Applications.RemoteMonitoring.Common.DeviceSchema
 {
     /// <summary>
     /// Helper class to encapsulate interactions with the device schema.
-    /// 
+    ///
     /// Elsewhere in the app we try to always deal with this flexible schema as dynamic,
-    /// but here we take a dependency on Json.Net where necessary to populate the objects 
+    /// but here we take a dependency on Json.Net where necessary to populate the objects
     /// behind the schema.
     /// </summary>
     public static class DeviceSchemaHelper
@@ -103,7 +104,7 @@ namespace Microsoft.Azure.Devices.Applications.RemoteMonitoring.Common.DeviceSch
         /// The Device instance from which to extract an Updated Time value.
         /// </param>
         /// <returns>
-        /// The Updated Time value, extracted from <paramref name="device" />, or 
+        /// The Updated Time value, extracted from <paramref name="device" />, or
         /// null if it is null or does not exist.
         /// </returns>
         public static DateTime? GetUpdatedTime(dynamic device)
@@ -140,7 +141,7 @@ namespace Microsoft.Azure.Devices.Applications.RemoteMonitoring.Common.DeviceSch
         /// Extracts a Hub Enabled State value from a Device instance.
         /// </summary>
         /// <param name="device">
-        /// The Device instance from which to extract a Hub Enabled State 
+        /// The Device instance from which to extract a Hub Enabled State
         /// value.
         /// </param>
         /// <returns>
@@ -162,7 +163,7 @@ namespace Microsoft.Azure.Devices.Applications.RemoteMonitoring.Common.DeviceSch
         }
 
         /// <summary>
-        /// Several aspects of the device schema can be modified after passing through and ASA Event Stream 
+        /// Several aspects of the device schema can be modified after passing through and ASA Event Stream
         /// or some other process. Fix up the schema to keep it clean.
         /// </summary>
         /// <param name="device"></param>
@@ -173,7 +174,7 @@ namespace Microsoft.Azure.Devices.Applications.RemoteMonitoring.Common.DeviceSch
         }
 
         /// <summary>
-        /// Verify that the hub enabled state is stored in the correct format, 
+        /// Verify that the hub enabled state is stored in the correct format,
         /// and try to fix incorrect formats if possible.
         /// </summary>
         /// <param name="device"></param>
@@ -191,15 +192,15 @@ namespace Microsoft.Azure.Devices.Applications.RemoteMonitoring.Common.DeviceSch
         }
 
         /// <summary>
-        /// Running the device through ASA can add certain unwanted properties that will persist in 
-        /// non-strongly typed schemas like Json. Remove those unwanted properties. It may be necessary 
-        /// to check the type of data we are working with and pass the object on to another private 
+        /// Running the device through ASA can add certain unwanted properties that will persist in
+        /// non-strongly typed schemas like Json. Remove those unwanted properties. It may be necessary
+        /// to check the type of data we are working with and pass the object on to another private
         /// helper method to handle that specific type of data.
         /// </summary>
         /// <param name="device"></param>
         private static void RemoveUnwantedAsaEventProperties(dynamic device)
         {
-            if(device.GetType() == typeof(JObject))
+            if (device.GetType() == typeof(JObject))
             {
                 RemoveUnwantedAsaEventPropertiesFromJObject((JObject)device);
             }
@@ -224,19 +225,7 @@ namespace Microsoft.Azure.Devices.Applications.RemoteMonitoring.Common.DeviceSch
         /// <returns>_rid property value as string, or empty string if not found</returns>
         public static string GetDocDbRid(dynamic device)
         {
-            if (device == null)
-            {
-                throw new ArgumentNullException("device");
-            }
-
-            dynamic rid = device._rid;
-
-            if (rid == null)
-            {
-                return "";
-            }
-
-            return rid.ToString();
+            return SchemaHelper.GetDocDbRid(device);
         }
 
         /// <summary>
@@ -246,19 +235,7 @@ namespace Microsoft.Azure.Devices.Applications.RemoteMonitoring.Common.DeviceSch
         /// <returns>Value of the id, or empty string if not found</returns>
         public static string GetDocDbId(dynamic device)
         {
-            if (device == null)
-            {
-                throw new ArgumentNullException("device");
-            }
-
-            dynamic id = device.id;
-
-            if (id == null)
-            {
-                return "";
-            }
-
-            return id.ToString();
+            return SchemaHelper.GetDocDbId(device);
         }
 
         /// <summary>

--- a/Common/Schema/SchemaHelper.cs
+++ b/Common/Schema/SchemaHelper.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using Microsoft.Azure.Devices.Applications.RemoteMonitoring.Common.Exceptions;
+using Microsoft.Azure.Devices.Applications.RemoteMonitoring.Common.Models;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.Azure.Devices.Applications.RemoteMonitoring.Common.Schema
+{
+    /// <summary>
+    /// Helper class to encapsulate interactions with the device schema.
+    ///
+    /// Elsewhere in the app we try to always deal with this flexible schema as dynamic,
+    /// but here we take a dependency on Json.Net where necessary to populate the objects
+    /// behind the schema.
+    /// </summary>
+    public static class SchemaHelper
+    {
+        /// <summary>
+        /// _rid is used internally by the DocDB and is required for use with DocDB.
+        /// (_rid is resource id)
+        /// </summary>
+        /// <param name="document">Device data</param>
+        /// <returns>_rid property value as string, or empty string if not found</returns>
+        public static string GetDocDbRid(dynamic document)
+        {
+            if (document == null)
+            {
+                throw new ArgumentNullException("document");
+            }
+
+            dynamic rid = document._rid;
+
+            if (rid == null)
+            {
+                return "";
+            }
+
+            return rid.ToString();
+        }
+
+        /// <summary>
+        /// id is used internally by the DocDB and is sometimes required.
+        /// </summary>
+        /// <param name="document">Device data</param>
+        /// <returns>Value of the id, or empty string if not found</returns>
+        public static string GetDocDbId(dynamic document)
+        {
+            if (document == null)
+            {
+                throw new ArgumentNullException("document");
+            }
+
+            dynamic id = document.id;
+
+            if (id == null)
+            {
+                return "";
+            }
+
+            return id.ToString();
+        }
+    }
+}

--- a/Common/Utility/IDocDbRestUtility.cs
+++ b/Common/Utility/IDocDbRestUtility.cs
@@ -8,11 +8,11 @@ namespace Microsoft.Azure.Devices.Applications.RemoteMonitoring.Common.Utility
     public interface IDocDbRestUtility
     {
         Task InitializeDatabase();
-        Task InitializeDeviceCollection();
-        Task<DocDbRestQueryResult> QueryDeviceManagementCollectionAsync(
+        Task InitializeCollection();
+        Task<DocDbRestQueryResult> QueryCollectionAsync(
             string queryString, Dictionary<string, Object> queryParams, int pageSize = -1, string continuationToken = null);
-        Task<JObject> SaveNewDeviceAsync(dynamic device);
-        Task<JObject> UpdateDeviceAsync(dynamic updatedDevice);
-        Task DeleteDeviceAsync(dynamic device);
+        Task<JObject> SaveNewDocumentAsync(dynamic document);
+        Task<JObject> UpdateDocumentAsync(dynamic updatedDocument);
+        Task DeleteDocumentAsync(dynamic document);
     }
 }

--- a/DeviceAdministration/Infrastructure/Repository/DeviceRegistryRepository.cs
+++ b/DeviceAdministration/Infrastructure/Repository/DeviceRegistryRepository.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.Devices.Applications.RemoteMonitoring.DeviceAdmin.Infr
 
             _docDbRestUtil = docDbRestUtil;
             Task.Run(() => _docDbRestUtil.InitializeDatabase()).Wait();
-            Task.Run(() => _docDbRestUtil.InitializeDeviceCollection()).Wait();
+            Task.Run(() => _docDbRestUtil.InitializeCollection()).Wait();
         }
 
         /// <summary>
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.Devices.Applications.RemoteMonitoring.DeviceAdmin.Infr
             int pageSize = 500;
             do
             {
-                DocDbRestQueryResult result = await _docDbRestUtil.QueryDeviceManagementCollectionAsync(query, null, pageSize, continuationToken);
+                DocDbRestQueryResult result = await _docDbRestUtil.QueryCollectionAsync(query, null, pageSize, continuationToken);
 
                 docs =
                     ReflectionHelper.GetNamedPropertyValue(
@@ -94,7 +94,7 @@ namespace Microsoft.Azure.Devices.Applications.RemoteMonitoring.DeviceAdmin.Infr
 
             Dictionary<string, Object> queryParams = new Dictionary<string, Object>();
             queryParams.Add("@id", deviceId);
-            DocDbRestQueryResult response = await _docDbRestUtil.QueryDeviceManagementCollectionAsync("SELECT VALUE root FROM root WHERE (root.DeviceProperties.DeviceID = @id)", queryParams);
+            DocDbRestQueryResult response = await _docDbRestUtil.QueryCollectionAsync("SELECT VALUE root FROM root WHERE (root.DeviceProperties.DeviceID = @id)", queryParams);
             JArray foundDevices = response.ResultSet;
 
             if (foundDevices != null && foundDevices.Count > 0)
@@ -121,7 +121,7 @@ namespace Microsoft.Azure.Devices.Applications.RemoteMonitoring.DeviceAdmin.Infr
                 throw new DeviceAlreadyRegisteredException(deviceId);
             }
 
-            device = await _docDbRestUtil.SaveNewDeviceAsync(device);
+            device = await _docDbRestUtil.SaveNewDocumentAsync(device);
 
             return device;
         }
@@ -135,7 +135,7 @@ namespace Microsoft.Azure.Devices.Applications.RemoteMonitoring.DeviceAdmin.Infr
                 throw new DeviceNotRegisteredException(deviceId);
             }
 
-            await _docDbRestUtil.DeleteDeviceAsync(existingDevice);
+            await _docDbRestUtil.DeleteDocumentAsync(existingDevice);
         }
 
         /// <summary>
@@ -157,7 +157,7 @@ namespace Microsoft.Azure.Devices.Applications.RemoteMonitoring.DeviceAdmin.Infr
 
             string incomingRid = DeviceSchemaHelper.GetDocDbRid(device);
 
-            if (string.IsNullOrWhiteSpace(incomingRid)) 
+            if (string.IsNullOrWhiteSpace(incomingRid))
             {
                 // copy the existing _rid onto the incoming data if needed
                 var existingRid = DeviceSchemaHelper.GetDocDbRid(existingDevice);
@@ -183,7 +183,7 @@ namespace Microsoft.Azure.Devices.Applications.RemoteMonitoring.DeviceAdmin.Infr
 
             DeviceSchemaHelper.UpdateUpdatedTime(device);
 
-            device = await _docDbRestUtil.UpdateDeviceAsync(device);
+            device = await _docDbRestUtil.UpdateDocumentAsync(device);
 
             return device;
         }
@@ -201,7 +201,7 @@ namespace Microsoft.Azure.Devices.Applications.RemoteMonitoring.DeviceAdmin.Infr
             deviceProps.HubEnabledState = isEnabled;
             DeviceSchemaHelper.UpdateUpdatedTime(existingDevice);
 
-            existingDevice = await _docDbRestUtil.UpdateDeviceAsync(existingDevice);
+            existingDevice = await _docDbRestUtil.UpdateDocumentAsync(existingDevice);
 
             return existingDevice;
         }
@@ -234,7 +234,7 @@ namespace Microsoft.Azure.Devices.Applications.RemoteMonitoring.DeviceAdmin.Infr
         }
 
         /// <summary>
-        /// Searches the DeviceProperties of the provided device list for the given search term 
+        /// Searches the DeviceProperties of the provided device list for the given search term
         /// (case insensitive)
         /// </summary>
         /// <param name="deviceList">List to searcn</param>
@@ -269,7 +269,7 @@ namespace Microsoft.Azure.Devices.Applications.RemoteMonitoring.DeviceAdmin.Infr
 
             // if the device or its system properties are null then
             // there's nothing that can be searched on
-            if ((device == null) || 
+            if ((device == null) ||
                 ((devProps = DeviceSchemaHelper.GetDeviceProperties(device)) == null))
             {
                 return false;


### PR DESCRIPTION
When working on 3rd party integration (porting resin.io integration to the new codebase) I've noticed I'd like to use the provided Doc DB REST util.

While it's completely generic by its nature it's locked to the devices collection (the only one used in the official repo, but I've introduced 2 more for my integration, and others may want to I think) in 2 ways:
- the way it names its methods and arguments
- the constructor

So I've renamed the methods, extracted generic schema routines, added another constructor (backward-compatible) and updated all the usages of the class (in Device Repository).

Getting this PR merged will significantly reduce deviation of my branch from master (while keeping it DRY), and simplify supporting it (I've spent a couple of hours recently rebasing against the upstream changes from the last couple of weeks).


Thanks in advance for your time.