### PR TITLE
Ignore case for Telemetry properties

### DIFF
--- a/Common/Helpers/ParsingHelper.cs
+++ b/Common/Helpers/ParsingHelper.cs
@@ -151,11 +151,11 @@ namespace Microsoft.Azure.Devices.Applications.RemoteMonitoring.Common.Helpers
                 }
                 else
                 {
-                    var currentItem = new Dictionary<string, string>();
+                    var currentItem = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
 
                     for (int i = 0; (i < row.Length) &&(i < firstRow.Length); ++i)
                     {
-                        currentItem[firstRow[i].ToLowerInvariant()] = row[i];
+                        currentItem[firstRow[i]] = row[i];
                     }
 
                     yield return currentItem;

--- a/Common/Helpers/ParsingHelper.cs
+++ b/Common/Helpers/ParsingHelper.cs
@@ -155,7 +155,7 @@ namespace Microsoft.Azure.Devices.Applications.RemoteMonitoring.Common.Helpers
 
                     for (int i = 0; (i < row.Length) &&(i < firstRow.Length); ++i)
                     {
-                        currentItem[firstRow[i]] = row[i];
+                        currentItem[firstRow[i].ToLowerInvariant()] = row[i];
                     }
 
                     yield return currentItem;

--- a/DeviceAdministration/Infrastructure/Repository/DeviceTelemetryRepository.cs
+++ b/DeviceAdministration/Infrastructure/Repository/DeviceTelemetryRepository.cs
@@ -252,12 +252,12 @@ namespace Microsoft.Azure.Devices.Applications.RemoteMonitoring.DeviceAdmin.Infr
                 {
                     model = new DeviceTelemetryModel();
 
-                    if (strdict.TryGetValue("DeviceId", out str))
+                    if (strdict.TryGetValue("deviceid", out str))
                     {
                         model.DeviceId = str;
                     }
 
-                    if (strdict.TryGetValue("ExternalTemperature", out str) &&
+                    if (strdict.TryGetValue("externaltemperature", out str) &&
                         double.TryParse(
                             str,
                             NumberStyles.Float,
@@ -267,7 +267,7 @@ namespace Microsoft.Azure.Devices.Applications.RemoteMonitoring.DeviceAdmin.Infr
                         model.ExternalTemperature = number;
                     }
 
-                    if (strdict.TryGetValue("Humidity", out str) &&
+                    if (strdict.TryGetValue("humidity", out str) &&
                         double.TryParse(
                             str,
                             NumberStyles.Float,
@@ -277,7 +277,7 @@ namespace Microsoft.Azure.Devices.Applications.RemoteMonitoring.DeviceAdmin.Infr
                         model.Humidity = number;
                     }
 
-                    if (strdict.TryGetValue("Temperature", out str) &&
+                    if (strdict.TryGetValue("temperature", out str) &&
                         double.TryParse(
                             str,
                             NumberStyles.Float,
@@ -288,7 +288,7 @@ namespace Microsoft.Azure.Devices.Applications.RemoteMonitoring.DeviceAdmin.Infr
                     }
 
                     DateTime date;
-                    if (strdict.TryGetValue("EventEnqueuedUtcTime", out str) &&
+                    if (strdict.TryGetValue("eventenqueuedutctime", out str) &&
                         DateTime.TryParse(
                             str, 
                             CultureInfo.InvariantCulture,


### PR DESCRIPTION
Summary already ignores case, so ignore case for Telemetry as well.  DeviceInfo is still case sensitive (requires larger change to make insensitive since it uses dynamic).  This addresses issue #123.