### PR TITLE
Process multiple blobs populated in parallel when fetching device telemetry

### DIFF
--- a/DeviceAdministration/Infrastructure/Repository/DeviceTelemetryRepository.cs
+++ b/DeviceAdministration/Infrastructure/Repository/DeviceTelemetryRepository.cs
@@ -80,7 +80,8 @@ namespace Microsoft.Azure.Devices.Applications.RemoteMonitoring.DeviceAdmin.Infr
                             null);
                     });
 
-            blobs = blobs.OrderByDescending(t => BlobStorageHelper.ExtractBlobItemDate(t));
+            blobs = blobs
+                .OrderByDescending(t => BlobStorageHelper.ExtractBlobItemDate(t));
 
             CloudBlockBlob blockBlob;
             IEnumerable<DeviceTelemetryModel> blobModels;
@@ -89,6 +90,16 @@ namespace Microsoft.Azure.Devices.Applications.RemoteMonitoring.DeviceAdmin.Infr
                 if ((blockBlob = blob as CloudBlockBlob) == null)
                 {
                     continue;
+                }
+
+                // Translate LastModified to local time zone.  DateTimeOffsets 
+                // don't do this automatically.  This is for equivalent behavior 
+                // with parsed DateTimes.
+                if ((blockBlob.Properties != null) &&
+                    blockBlob.Properties.LastModified.HasValue &&
+                    (blockBlob.Properties.LastModified.Value.LocalDateTime < minTime))
+                {
+                    break;
                 }
 
                 try
@@ -120,11 +131,6 @@ namespace Microsoft.Azure.Devices.Applications.RemoteMonitoring.DeviceAdmin.Infr
                 }
 
                 result = result.Concat(blobModels);
-
-                if (preFilterCount != blobModels.Count())
-                {
-                    break;
-                }
             }
 
             if (!string.IsNullOrEmpty(deviceId))


### PR DESCRIPTION
This fix allows the service to pull multiple blobs from the *devicetelemetry* directory with overlapping write times, instead of assuming that only one blob is written to at a time.

This is useful because any change in schema for device telemetry will result in a new blob being emitted from Stream Analytics. Problem cases that this PR resolves include:

* Messages that are sent with different case for the same field (e.g. DeviceId vs. DeviceID)
* Messages that are sent with the same columns, but in a different order
* Messages that are sent with additional/different fields (dynamic telemetry)