### PR TITLE
Adding provision link to device details when enable state is null

### DIFF
--- a/DeviceAdministration/Web/Controllers/DeviceController.cs
+++ b/DeviceAdministration/Web/Controllers/DeviceController.cs
@@ -377,5 +377,9 @@ namespace Microsoft.Azure.Devices.Applications.RemoteMonitoring.DeviceAdmin.Web.
             return devices.Results;
         }
 
+        public ActionResult ProvisionDevice(string deviceid)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/DeviceAdministration/Web/Models/DeviceDetailModel.cs
+++ b/DeviceAdministration/Web/Models/DeviceDetailModel.cs
@@ -119,5 +119,10 @@ namespace Microsoft.Azure.Devices.Applications.RemoteMonitoring.DeviceAdmin.Web.
             get;
             set;
         }
+
+        public bool CanProvision
+        {
+            get { return HubEnabledState == null; }
+        }
     }
 }

--- a/DeviceAdministration/Web/Views/Device/_DeviceDetails.cshtml
+++ b/DeviceAdministration/Web/Views/Device/_DeviceDetails.cshtml
@@ -54,6 +54,18 @@
             </p>
         }
 
+        @if (Model.CanProvision)
+        {
+            <p id="provisionDeviceLink"
+               class="grid_detail_value">
+                @Html.ActionLink("Provision Device",
+                    "ProvisionDevice",
+                    "Device",
+                    new { deviceId = Model.DeviceID },
+                    null)
+            </p>
+        }
+
         @if (Model.CanRemoveDevice)
         {
             <p id="removeDeviceLink"


### PR DESCRIPTION
Added a link to the device details pane when the device is not provisioned.