### PR TITLE
Allow anonymous API access and outside in test suite stub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -202,3 +202,6 @@ VendingMachineSample/packages/*
 
 # Merge file remains
 *.orig
+
+#Node
+node_modules

--- a/DeviceAdministration/Web/Web.csproj
+++ b/DeviceAdministration/Web/Web.csproj
@@ -37,7 +37,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;CODE_ANALYSIS; SUPPRESS_CSRF_PROTECTION; ALLOW_ANONYMOUS_API</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>

--- a/DeviceAdministration/Web/WebApiControllers/WebApiControllerBase.cs
+++ b/DeviceAdministration/Web/WebApiControllers/WebApiControllerBase.cs
@@ -14,6 +14,9 @@ using Microsoft.Azure.Devices.Applications.RemoteMonitoring.DeviceAdmin.Web.Secu
 namespace Microsoft.Azure.Devices.Applications.RemoteMonitoring.DeviceAdmin.Web.WebApiControllers
 {
     [Authorize]
+#if ALLOW_ANONYMOUS_API
+    [AllowAnonymous]
+#endif
     [WebApiCSRFValidation]
     public abstract class WebApiControllerBase : ApiController
     {

--- a/apitests/.eslintrc.yml
+++ b/apitests/.eslintrc.yml
@@ -1,0 +1,19 @@
+env:
+  node: true
+  commonjs: true
+  es6: true
+  jasmine: true
+extends: 'eslint:recommended'
+rules:
+  indent:
+    - error
+    - 4
+  linebreak-style:
+    - error
+    - windows
+  quotes:
+    - error
+    - single
+  semi:
+    - error
+    - always

--- a/apitests/jsconfig.json
+++ b/apitests/jsconfig.json
@@ -1,0 +1,16 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=759670
+	// for the documentation about the jsconfig.json format
+	"compilerOptions": {
+		"target": "es6",
+		"module": "commonjs",
+		"allowSyntheticDefaultImports": true
+	},
+	"exclude": [
+		"node_modules",
+		"bower_components",
+		"jspm_packages",
+		"tmp",
+		"temp"
+	]
+}

--- a/apitests/package.json
+++ b/apitests/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "apitests",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "jasmine"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "jasmine": "^2.4.1",
+    "request": "^2.73.0"
+  },
+  "devDependencies": {
+    "eslint": "^3.0.1",
+    "eslint-config-airbnb": "^9.0.1",
+    "eslint-plugin-react": "^5.2.2"
+  }
+}

--- a/apitests/spec/devices_spec.js
+++ b/apitests/spec/devices_spec.js
@@ -1,0 +1,34 @@
+const request = require('request').defaults({ json: true, baseUrl: 'https://localhost:44305/api/v1/devices' });
+
+describe('devices api', () => {
+    describe('get devices', () => {
+        it('should return list of devices', (done) => {
+            request.get('', (err, resp, result) => {
+                expect(result).toBeTruthy();
+                expect(result.data).toBeTruthy();
+                expect(result.data.length).toBeGreaterThan(0);
+                done();
+            });
+        });
+
+        it('should return device properties', (done) => {
+            request.get('', (err, resp, result) => {
+                expect(result.data[0].DeviceProperties).toBeTruthy();
+                expect(result.data[0].DeviceProperties.DeviceID).toBeTruthy();
+                expect(result.data[0].DeviceProperties.HubEnabledState).toBeDefined();
+                expect(result.data[0].DeviceProperties.CreatedTime).toBeTruthy();
+                expect(result.data[0].DeviceProperties.DeviceState).toBeTruthy();
+                expect(result.data[0].DeviceProperties.UpdatedTime).toBeDefined();
+                done();
+            });
+        });
+
+        it('should return system properties', (done) => {
+            request.get('', (err, resp, result) => {
+                expect(result.data[0].SystemProperties).toBeTruthy();
+                expect(result.data[0].SystemProperties.ICCID).toBeDefined();
+                done();
+            });
+        });
+    });
+});

--- a/apitests/spec/helpers/env.js
+++ b/apitests/spec/helpers/env.js
@@ -1,0 +1,2 @@
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
+

--- a/apitests/spec/support/jasmine.json
+++ b/apitests/spec/support/jasmine.json
@@ -1,0 +1,11 @@
+{
+  "spec_dir": "spec",
+  "spec_files": [
+    "**/*[sS]pec.js"
+  ],
+  "helpers": [
+    "helpers/**/*.js"
+  ],
+  "stopSpecOnExpectationFailure": false,
+  "random": false
+}


### PR DESCRIPTION
Allowing a preprocessor directive to disable auth for API endpoints and added a node test suite for outside in testing using jasmine and request. 