### PR TITLE
Unit test fix for non US-locale environments

### DIFF
--- a/UnitTests/Infrastructure/AlertsRepositoryTests.cs
+++ b/UnitTests/Infrastructure/AlertsRepositoryTests.cs
@@ -42,21 +42,21 @@ namespace Microsoft.Azure.Devices.Applications.RemoteMonitoring.UnitTests.Infras
             var value = "10.0";
             var minTime = new DateTime(year, month, date);
 
-            await
-                Assert.ThrowsAsync<ArgumentOutOfRangeException>(
-                    async () => await alertsRepository.LoadLatestAlertHistoryAsync(minTime, 0));
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => await alertsRepository.LoadLatestAlertHistoryAsync(minTime, 0));
 
             var blobReader = new Mock<IBlobStorageReader>();
-            var blobData = "deviceid,reading,ruleoutput,time" + Environment.NewLine + "Device123," + value +
-                           ",RuleOutput123," + minTime;
+             var blobData = $"deviceid,reading,ruleoutput,time,{Environment.NewLine}Device123,{value},RuleOutput123,{minTime.ToString("o")}";
             var stream = new MemoryStream(Encoding.UTF8.GetBytes(blobData));
-            var blobContents = new BlobContents {Data = stream, LastModifiedTime = DateTime.Now};
+            var blobContents = new BlobContents {Data = stream, LastModifiedTime = DateTime.UtcNow};
             var blobContentIterable = new List<BlobContents>();
             blobContentIterable.Add(blobContents);
 
             blobReader.Setup(x => x.GetEnumerator()).Returns(blobContentIterable.GetEnumerator());
-            _blobStorageClientMock.Setup(x => x.GetReader(It.IsNotNull<string>(), It.IsAny<DateTime?>()))
+
+            _blobStorageClientMock
+                .Setup(x => x.GetReader(It.IsNotNull<string>(), It.IsAny<DateTime?>()))
                 .ReturnsAsync(blobReader.Object);
+
             var alertsList = await alertsRepository.LoadLatestAlertHistoryAsync(minTime, 5);
             Assert.NotNull(alertsList);
             Assert.NotEmpty(alertsList);

--- a/UnitTests/Infrastructure/DeviceTelemetryRepositoryTest.cs
+++ b/UnitTests/Infrastructure/DeviceTelemetryRepositoryTest.cs
@@ -43,12 +43,11 @@ namespace Microsoft.Azure.Devices.Applications.RemoteMonitoring.UnitTests.Infras
             var minTime = new DateTime(year, month, date);
 
             var blobReader = new Mock<IBlobStorageReader>();
-            var blobData =
-                "deviceid,temperature,humidity,externaltemperature,eventprocessedutctime,partitionid,eventenqueuedutctime,IoTHub" +
+            var blobData = "deviceid,temperature,humidity,externaltemperature,eventprocessedutctime,partitionid,eventenqueuedutctime,IoTHub" +
                 Environment.NewLine +
-                "test1,34.200411299709423,32.2233033525866,,2016 - 08 - 04T23: 07:14.2549606Z,3," + minTime + ",Record";
+                "test1,34.200411299709423,32.2233033525866,,2016 - 08 - 04T23: 07:14.2549606Z,3," + minTime.ToString("o") + ",Record";
             var stream = new MemoryStream(Encoding.UTF8.GetBytes(blobData));
-            var blobContents = new BlobContents {Data = stream, LastModifiedTime = DateTime.Now};
+            var blobContents = new BlobContents {Data = stream, LastModifiedTime = DateTime.UtcNow};
             var blobContentIterable = new List<BlobContents>();
             blobContentIterable.Add(blobContents);
 
@@ -74,7 +73,7 @@ namespace Microsoft.Azure.Devices.Applications.RemoteMonitoring.UnitTests.Infras
             var blobData = "deviceid,averagehumidity,minimumhumidity,maxhumidity,timeframeminutes" + Environment.NewLine +
                            "test2,37.806204872115607,37.806204872115607,37.806204872115607,5";
             var stream = new MemoryStream(Encoding.UTF8.GetBytes(blobData));
-            var blobContents = new BlobContents {Data = stream, LastModifiedTime = DateTime.Now};
+            var blobContents = new BlobContents {Data = stream, LastModifiedTime = DateTime.UtcNow};
             var blobContentIterable = new List<BlobContents>();
             blobContentIterable.Add(blobContents);
 

--- a/UnitTests/Infrastructure/DeviceTelemetryRepositoryTest.cs
+++ b/UnitTests/Infrastructure/DeviceTelemetryRepositoryTest.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.Devices.Applications.RemoteMonitoring.UnitTests.Infras
             var blobReader = new Mock<IBlobStorageReader>();
             var blobData = "deviceid,temperature,humidity,externaltemperature,eventprocessedutctime,partitionid,eventenqueuedutctime,IoTHub" +
                 Environment.NewLine +
-                "test1,34.200411299709423,32.2233033525866,,2016 - 08 - 04T23: 07:14.2549606Z,3," + minTime.ToString("o") + ",Record";
+                "test1,34.200411299709423,32.2233033525866,,2016-08-04T23:07:14.2549606Z,3," + minTime.ToString("o") + ",Record";
             var stream = new MemoryStream(Encoding.UTF8.GetBytes(blobData));
             var blobContents = new BlobContents {Data = stream, LastModifiedTime = DateTime.UtcNow};
             var blobContentIterable = new List<BlobContents>();


### PR DESCRIPTION
Using DateTime.UtcNOw and roundtrip date formats for mock JSON.