### PR TITLE
Fix issue #403: Error upgrading deployment to latest revision

### DIFF
--- a/Common/Deployment/PrepareIoTSample.ps1
+++ b/Common/Deployment/PrepareIoTSample.ps1
@@ -167,7 +167,7 @@ if ($cloudDeploy)
         $webSku = GetResourceObject $suitename $suitename Microsoft.Web/sites
         $params += @{webSku=$($webSku.Properties.Sku)}
         $webPlan = GetResourceObject $suiteName ("{0}-plan" -f $suiteName) Microsoft.Web/serverfarms
-        $params += @{webWorkerSize=$($webPlan.Properties.WorkerSize)}
+        $params += @{webWorkerSize=$($webPlan.Properties.WorkerSizeId)}
         $params += @{webWorkerCount=$($webPlan.Properties.NumberOfWorkers)}
         $jobName = "{0}-jobhost" -f $suitename
         if (ResourceObjectExists $suitename $jobName Microsoft.Web/sites)
@@ -175,7 +175,7 @@ if ($cloudDeploy)
             $webJobSku = GetResourceObject $suitename $jobName Microsoft.Web/sites
             $params += @{webJobSku=$($webJobSku.Properties.Sku)}
             $webJobPlan = GetResourceObject $suiteName ("{0}-jobsplan" -f $suiteName) Microsoft.Web/serverfarms
-            $params += @{webJobWorkerSize=$($webJobPlan.Properties.WorkerSize)}
+            $params += @{webJobWorkerSize=$($webJobPlan.Properties.WorkerSizeId)}
             $params += @{webJobWorkerCount=$($webJobPlan.Properties.NumberOfWorkers)}
         }
     }


### PR DESCRIPTION
This issue was caused by mismatched property. In previous code, we are going to retrieve the existing server farm worker size from property 'WorkerSize', then use it as parameter of the deployment template. Currently, this property will return a human readable string, such as 'Small' or 'Medium'. While the template requires the size being presented in integer, such as 0, 1, 2 and so on. That is why it will cause a deployment template validation error. In this code change, we are going to switch a different property 'WorkerSizeId' which is presented in the desired format.

Btw, the fix was confirmed by customer - 'I can confirm that this fixes the issue with WorkerSize.'

For the issue, please check: https://github.com/Azure/azure-iot-remote-monitoring/issues/403

@joyhui @zhang-hua @darrenchuang 