### PR TITLE
CultureInfo fix to two unit tests that was failing with Danish culture set.

### DIFF
--- a/UnitTests/Infrastructure/DeviceLogicWithIoTHubDMTests.cs
+++ b/UnitTests/Infrastructure/DeviceLogicWithIoTHubDMTests.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Azure.Devices.Applications.RemoteMonitoring.UnitTests.Infras
             var device = this.fixture.Create<DeviceModel>();
             device.Twin.Tags["x"] = "one";
             device.Twin.Properties.Desired["y"] = 2;
-            device.Twin.Properties.Reported["z"] = now;
+            device.Twin.Properties.Reported["z"] = now.ToString(CultureInfo.InvariantCulture);;
 
             this._configProviderMock.Setup(mock => mock.GetConfigurationSettingValue("iotHub.HostName")).Returns("hostName");
             var res = this._deviceLogic.ExtractDevicePropertyValuesModels(device);

--- a/UnitTests/Web/Controllers/DeviceRulesControllerTests.cs
+++ b/UnitTests/Web/Controllers/DeviceRulesControllerTests.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Azure.Devices.Applications.RemoteMonitoring.UnitTests.Web
             var tableResponse = fixture.Create<TableStorageResponse<DeviceRule>>();
             tableResponse.Status = TableStorageResponseStatus.Successful;
             model = fixture.Create<EditDeviceRuleModel>();
-            model.Threshold = "2.14";
+            model.Threshold = 2.14.ToString(CultureInfo.CurrentCulture);
             _deviceRulesMock.Setup(mock => mock.SaveDeviceRuleAsync(It.IsAny<DeviceRule>()))
                 .ReturnsAsync(tableResponse)
                 .Verifiable();
@@ -82,7 +82,7 @@ namespace Microsoft.Azure.Devices.Applications.RemoteMonitoring.UnitTests.Web
             tableResponse = fixture.Create<TableStorageResponse<DeviceRule>>();
             tableResponse.Status = TableStorageResponseStatus.ConflictError;
             model = fixture.Create<EditDeviceRuleModel>();
-            model.Threshold = "2.14";
+            model.Threshold = 2.14.ToString(CultureInfo.CurrentCulture);
             _deviceRulesMock.Setup(mock => mock.SaveDeviceRuleAsync(It.IsAny<DeviceRule>()))
                 .ReturnsAsync(tableResponse)
                 .Verifiable();

--- a/UnitTests/Web/Controllers/DeviceRulesControllerTests.cs
+++ b/UnitTests/Web/Controllers/DeviceRulesControllerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Web.Mvc;
 using Microsoft.Azure.Devices.Applications.RemoteMonitoring.Common.Models;
 using Microsoft.Azure.Devices.Applications.RemoteMonitoring.DeviceAdmin.Infrastructure.BusinessLogic;


### PR DESCRIPTION
Corrected two unit tests that fails when running the unit tests on a computer with e.g. Danish culture set.