### PR TITLE
Bug fix of checking multiple versions of Azure Powershell modules

### DIFF
--- a/Common/Deployment/DeploymentLib.ps1
+++ b/Common/Deployment/DeploymentLib.ps1
@@ -984,6 +984,10 @@ $global:azureVersion = "2.0.0"
 # Check version
 $module = Get-Module -ListAvailable | Where-Object{ $_.Name -eq 'Azure' }
 $expected = New-Object System.Version($global:azureVersion)
+if($module -is [System.Array])
+{
+    $module = ($module | Sort-Object Version -Descending)[0]
+}
 $comparison = $expected.CompareTo($module.Version)
 
 if ($comparison -eq 1)


### PR DESCRIPTION
The current script throw exception when multiple versions of Azure
Powershell modules installed. So we compare the latest version against the
required version if there are multiple version exists.