### PR TITLE
Fix customer corrupt DNS resolution issue

### DIFF
--- a/Common/Deployment/PrepareIoTSample.ps1
+++ b/Common/Deployment/PrepareIoTSample.ps1
@@ -69,6 +69,8 @@ $global:azureEnvironment = Get-AzureEnvironment $azureEnvironmentName
 $environmentName = $environmentName.ToLowerInvariant()
 . "$(Split-Path $MyInvocation.MyCommand.Path)\DeploymentLib.ps1"
 ClearDNSCache
+DetectIoTHubDNS
+DetectDocdbDNS
 
 # Sets Azure Accounts, Region, Name validation, and AAD application
 InitializeEnvironment $environmentName
@@ -242,10 +244,10 @@ if ($environmentName -ne "local")
 {
     $maxSleep = 40
     $webEndpoint = "{0}.{1}" -f $environmentName, $global:websiteSuffix
-    if (!(HostEntryExists $webEndpoint))
+    if (!(Test-AzureName -Website $webEndpoint))
     {
         Write-Host "Waiting for website url to resolve." -NoNewline
-        while (!(HostEntryExists $webEndpoint))
+        while (!(Test-AzureName -Website $webEndpoint))
         {
             Write-Host "." -NoNewline
             Clear-DnsClientCache
@@ -259,7 +261,7 @@ if ($environmentName -ne "local")
         }
         Write-Host
     }
-    if (HostEntryExists $webEndpoint)
+    if (Test-AzureName -Website $webEndpoint)
     {
         start $global:site
     }


### PR DESCRIPTION
This issue is reported as
[430](https://github.com/Azure/azure-iot-remote-monitoring/issues/430)
on github by customer whose DNS server always return a default ip ddress even it doesn't exit.
This prevents the customer to provision remote monitoring solution.